### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,10 @@
   "test_pattern": "_test\\.dart$",
   "exercises": [
     {
+      "uuid": "93ed6692-5f4e-477d-9bce-9e76999e1f1f",
       "slug": "hello-world",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (conditionals)",
@@ -16,7 +19,10 @@
       ]
     },
     {
+      "uuid": "d06437d7-e5d0-4fe1-a22f-883d3c35f7eb",
       "slug": "leap",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Booleans",
@@ -25,7 +31,10 @@
       ]
     },
     {
+      "uuid": "d4fed623-39da-43f8-8d34-8c9e68c67217",
       "slug": "hamming",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (loops)",
@@ -35,7 +44,10 @@
       ]
     },
     {
+      "uuid": "69ef6894-ffd5-431b-ab3e-9f20d8d5741c",
       "slug": "rna-transcription",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Strings",
@@ -43,7 +55,10 @@
       ]
     },
     {
+      "uuid": "8b67deea-286c-4c99-b1f0-9493cfd445f9",
       "slug": "bob",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control flow (conditionals)",
@@ -55,23 +70,26 @@
       ]
     },
     {
+      "uuid": "a356c21f-2de3-49a8-a9f1-962d8c9e84c1",
       "slug": "gigasecond",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Time"
       ]
     },
     {
+      "uuid": "6e251bc8-aa24-46df-b7d4-25a6c22fdce7",
       "slug": "difference-of-squares",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Integers",
         "Mathematics"
       ]
     }
-  ],
-  "deprecated": [
-
   ],
   "foregone": [
 


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the [progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md) design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming that this is a core exercise, but there is no reason that it needs to be.

Until now we have operated with a separate deprecated array. These are now being moved into the exercises array with a deprecated field.

With these defaults the track in nextercism will have no core exercises, and all the exercises will be available as 'extras' from the start.

If you haven't already, now would be a good time to do the following:

* add a rough estimate of difficulty to each exercise (scale: 1-10)
* add topics to each exercise
* choose *at most 20 exercises* to be core exercises (set core: true, and delete the unlocked_by key)
* for each exercise that is not core, decide which exercise is the prerequisite (max 1)

If possible, leave 3 or 4 simple exercises as (core: false, unlocked_by: null), as this will provide new participants with some exercises that they can tackle even if they have not finished the first core exercise.


See https://github.com/exercism/meta/issues/16