### PR TITLE
Update comment in Bob to decode other string

### DIFF
--- a/exercises/bob/test/bob_test.dart
+++ b/exercises/bob/test/bob_test.dart
@@ -72,6 +72,8 @@ void main() {
       ///   \xdc = Ü
       ///   \xfc = ü
       ///
+      ///   "\xdcML\xc4\xdcTS" === "ÜMLÄÜTS"
+      ///
       ///   "\xfcML\xe4\xdcTS" === "üMLäÜTS"
 
       final result = bob.hey("\xdcML\xc4\xdcTS!");


### PR DESCRIPTION
Noticed we decode one string, but not the other.

Also not sure if we want to move the decoded string comment to the test where the string resides.