### PR TITLE
Run all tests in Travis and revise dependency versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,16 @@ dart:
 dart_task:
   - test: --platform vm
 
+branches:
+  only:
+  - master
+
 cache:
   directories:
     - $HOME/.pub-cache
 
 before_script:
-  - |
-    unformatted="$(pub run dart_style:format -l 120 -n .)"
-    if [ ! -z "$unformatted" ]; then
-      echo "Files are unformatted:"
-      echo "$unformatted"
-      exit 1
-    fi
+  - bin/check_formatting
 
 script:
   - bin/fetch-configlet

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,4 @@ before_script:
 script:
   - bin/fetch-configlet
   - bin/configlet lint .
+  - pub run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ dart:
 dart_task:
   - test: --platform vm
 
-branches:
-  only:
-  - master
-
 cache:
   directories:
     - $HOME/.pub-cache

--- a/bin/check_formatting
+++ b/bin/check_formatting
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+unformatted="$(pub run dart_style:format -l 120 -n .)"
+
+if [ ! -z "$unformatted" ]; then
+  echo "Files are unformatted:"
+  echo "$unformatted"
+  exit 1
+fi

--- a/exercises/bob/pubspec.lock
+++ b/exercises/bob/pubspec.lock
@@ -6,13 +6,13 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.30.0+2"
+    version: "0.30.0+4"
   args:
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.7"
+    version: "1.0.0"
   async:
     description:
       name: async
@@ -24,7 +24,7 @@ packages:
       name: barback
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.2+11"
+    version: "0.15.2+12"
   boolean_selector:
     description:
       name: boolean_selector
@@ -42,7 +42,7 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.1.2+1"
   collection:
     description:
       name: collection
@@ -60,25 +60,25 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.2+1"
   csslib:
     description:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0"
+    version: "0.14.1"
   front_end:
     description:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-alpha.4"
+    version: "0.1.0-alpha.4.1"
   glob:
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.5"
   html:
     description:
       name: html
@@ -90,13 +90,13 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+14"
+    version: "0.11.3+15"
   http_multi_server:
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   http_parser:
     description:
       name: http_parser
@@ -108,7 +108,7 @@ packages:
       name: isolate
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   js:
     description:
       name: js
@@ -120,7 +120,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0-alpha.1"
+    version: "0.3.0-alpha.1.1"
   logging:
     description:
       name: logging
@@ -132,13 +132,13 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.1+2"
+    version: "0.12.1+4"
   meta:
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   mime:
     description:
       name: mime
@@ -156,7 +156,7 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   package_resolver:
     description:
       name: package_resolver
@@ -174,13 +174,13 @@ packages:
       name: plugin
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0+1"
+    version: "0.2.0+2"
   pool:
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   pub_semver:
     description:
       name: pub_semver
@@ -198,7 +198,7 @@ packages:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   shelf_static:
     description:
       name: shelf_static
@@ -210,7 +210,7 @@ packages:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   source_map_stack_trace:
     description:
       name: source_map_stack_trace
@@ -234,13 +234,13 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   stream_channel:
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.1"
+    version: "1.6.2"
   string_scanner:
     description:
       name: string_scanner
@@ -258,13 +258,13 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.24+2"
+    version: "0.12.24+8"
   typed_data:
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.4"
+    version: "1.1.5"
   utf:
     description:
       name: utf
@@ -276,18 +276,18 @@ packages:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+3"
+    version: "0.9.7+4"
   web_socket_channel:
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.6"
   yaml:
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.12"
+    version: "2.1.13"
 sdks:
   dart: ">=1.23.0 <2.0.0-dev.infinity"

--- a/exercises/difference-of-squares/pubspec.lock
+++ b/exercises/difference-of-squares/pubspec.lock
@@ -6,13 +6,13 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.30.0+2"
+    version: "0.30.0+4"
   args:
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.7"
+    version: "1.0.0"
   async:
     description:
       name: async
@@ -24,7 +24,7 @@ packages:
       name: barback
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.2+11"
+    version: "0.15.2+12"
   boolean_selector:
     description:
       name: boolean_selector
@@ -42,7 +42,7 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.1.2+1"
   collection:
     description:
       name: collection
@@ -60,25 +60,25 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.2+1"
   csslib:
     description:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0"
+    version: "0.14.1"
   front_end:
     description:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-alpha.4"
+    version: "0.1.0-alpha.4.1"
   glob:
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.5"
   html:
     description:
       name: html
@@ -90,13 +90,13 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+14"
+    version: "0.11.3+15"
   http_multi_server:
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   http_parser:
     description:
       name: http_parser
@@ -108,7 +108,7 @@ packages:
       name: isolate
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   js:
     description:
       name: js
@@ -120,7 +120,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0-alpha.1"
+    version: "0.3.0-alpha.1.1"
   logging:
     description:
       name: logging
@@ -132,13 +132,13 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.1+2"
+    version: "0.12.1+4"
   meta:
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   mime:
     description:
       name: mime
@@ -156,7 +156,7 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   package_resolver:
     description:
       name: package_resolver
@@ -174,13 +174,13 @@ packages:
       name: plugin
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0+1"
+    version: "0.2.0+2"
   pool:
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   pub_semver:
     description:
       name: pub_semver
@@ -198,7 +198,7 @@ packages:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   shelf_static:
     description:
       name: shelf_static
@@ -210,7 +210,7 @@ packages:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   source_map_stack_trace:
     description:
       name: source_map_stack_trace
@@ -234,13 +234,13 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   stream_channel:
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.1"
+    version: "1.6.2"
   string_scanner:
     description:
       name: string_scanner
@@ -258,13 +258,13 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.24+2"
+    version: "0.12.24+8"
   typed_data:
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.4"
+    version: "1.1.5"
   utf:
     description:
       name: utf
@@ -276,18 +276,18 @@ packages:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+3"
+    version: "0.9.7+4"
   web_socket_channel:
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.6"
   yaml:
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.12"
+    version: "2.1.13"
 sdks:
   dart: ">=1.23.0 <2.0.0-dev.infinity"

--- a/exercises/gigasecond/pubspec.lock
+++ b/exercises/gigasecond/pubspec.lock
@@ -6,13 +6,13 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.30.0+2"
+    version: "0.30.0+4"
   args:
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.7"
+    version: "1.0.0"
   async:
     description:
       name: async
@@ -24,7 +24,7 @@ packages:
       name: barback
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.2+11"
+    version: "0.15.2+12"
   boolean_selector:
     description:
       name: boolean_selector
@@ -42,7 +42,7 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.1.2+1"
   collection:
     description:
       name: collection
@@ -60,25 +60,25 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.2+1"
   csslib:
     description:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0"
+    version: "0.14.1"
   front_end:
     description:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-alpha.4"
+    version: "0.1.0-alpha.4.1"
   glob:
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.5"
   html:
     description:
       name: html
@@ -90,13 +90,13 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+14"
+    version: "0.11.3+15"
   http_multi_server:
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   http_parser:
     description:
       name: http_parser
@@ -108,7 +108,7 @@ packages:
       name: isolate
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   js:
     description:
       name: js
@@ -120,7 +120,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0-alpha.1"
+    version: "0.3.0-alpha.1.1"
   logging:
     description:
       name: logging
@@ -132,13 +132,13 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.1+2"
+    version: "0.12.1+4"
   meta:
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   mime:
     description:
       name: mime
@@ -156,7 +156,7 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   package_resolver:
     description:
       name: package_resolver
@@ -174,13 +174,13 @@ packages:
       name: plugin
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0+1"
+    version: "0.2.0+2"
   pool:
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   pub_semver:
     description:
       name: pub_semver
@@ -198,7 +198,7 @@ packages:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   shelf_static:
     description:
       name: shelf_static
@@ -210,7 +210,7 @@ packages:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   source_map_stack_trace:
     description:
       name: source_map_stack_trace
@@ -234,13 +234,13 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   stream_channel:
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.1"
+    version: "1.6.2"
   string_scanner:
     description:
       name: string_scanner
@@ -258,13 +258,13 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.24+2"
+    version: "0.12.24+8"
   typed_data:
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.4"
+    version: "1.1.5"
   utf:
     description:
       name: utf
@@ -276,18 +276,18 @@ packages:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+3"
+    version: "0.9.7+4"
   web_socket_channel:
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.6"
   yaml:
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.12"
+    version: "2.1.13"
 sdks:
   dart: ">=1.23.0 <2.0.0-dev.infinity"

--- a/exercises/hamming/pubspec.lock
+++ b/exercises/hamming/pubspec.lock
@@ -6,13 +6,13 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.30.0+2"
+    version: "0.30.0+4"
   args:
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.7"
+    version: "1.0.0"
   async:
     description:
       name: async
@@ -24,7 +24,7 @@ packages:
       name: barback
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.2+11"
+    version: "0.15.2+12"
   boolean_selector:
     description:
       name: boolean_selector
@@ -42,7 +42,7 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.1.2+1"
   collection:
     description:
       name: collection
@@ -60,25 +60,25 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.2+1"
   csslib:
     description:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0"
+    version: "0.14.1"
   front_end:
     description:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-alpha.4"
+    version: "0.1.0-alpha.4.1"
   glob:
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.5"
   html:
     description:
       name: html
@@ -90,13 +90,13 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+14"
+    version: "0.11.3+15"
   http_multi_server:
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   http_parser:
     description:
       name: http_parser
@@ -108,7 +108,7 @@ packages:
       name: isolate
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   js:
     description:
       name: js
@@ -120,7 +120,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0-alpha.1"
+    version: "0.3.0-alpha.1.1"
   logging:
     description:
       name: logging
@@ -132,13 +132,13 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.1+2"
+    version: "0.12.1+4"
   meta:
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   mime:
     description:
       name: mime
@@ -156,7 +156,7 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   package_resolver:
     description:
       name: package_resolver
@@ -174,13 +174,13 @@ packages:
       name: plugin
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0+1"
+    version: "0.2.0+2"
   pool:
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   pub_semver:
     description:
       name: pub_semver
@@ -198,7 +198,7 @@ packages:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   shelf_static:
     description:
       name: shelf_static
@@ -210,7 +210,7 @@ packages:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   source_map_stack_trace:
     description:
       name: source_map_stack_trace
@@ -234,13 +234,13 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   stream_channel:
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.1"
+    version: "1.6.2"
   string_scanner:
     description:
       name: string_scanner
@@ -258,13 +258,13 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.24+2"
+    version: "0.12.24+8"
   typed_data:
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.4"
+    version: "1.1.5"
   utf:
     description:
       name: utf
@@ -276,18 +276,18 @@ packages:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+3"
+    version: "0.9.7+4"
   web_socket_channel:
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.6"
   yaml:
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.12"
+    version: "2.1.13"
 sdks:
   dart: ">=1.23.0 <2.0.0-dev.infinity"

--- a/exercises/hello-world/pubspec.lock
+++ b/exercises/hello-world/pubspec.lock
@@ -6,13 +6,13 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.30.0+2"
+    version: "0.30.0+4"
   args:
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.7"
+    version: "1.0.0"
   async:
     description:
       name: async
@@ -24,7 +24,7 @@ packages:
       name: barback
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.2+11"
+    version: "0.15.2+12"
   boolean_selector:
     description:
       name: boolean_selector
@@ -42,7 +42,7 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.1.2+1"
   collection:
     description:
       name: collection
@@ -60,25 +60,25 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.2+1"
   csslib:
     description:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0"
+    version: "0.14.1"
   front_end:
     description:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-alpha.4"
+    version: "0.1.0-alpha.4.1"
   glob:
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.5"
   html:
     description:
       name: html
@@ -90,13 +90,13 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+14"
+    version: "0.11.3+15"
   http_multi_server:
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   http_parser:
     description:
       name: http_parser
@@ -108,7 +108,7 @@ packages:
       name: isolate
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   js:
     description:
       name: js
@@ -120,7 +120,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0-alpha.1"
+    version: "0.3.0-alpha.1.1"
   logging:
     description:
       name: logging
@@ -132,13 +132,13 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.1+2"
+    version: "0.12.1+4"
   meta:
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   mime:
     description:
       name: mime
@@ -156,7 +156,7 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   package_resolver:
     description:
       name: package_resolver
@@ -174,13 +174,13 @@ packages:
       name: plugin
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0+1"
+    version: "0.2.0+2"
   pool:
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   pub_semver:
     description:
       name: pub_semver
@@ -198,7 +198,7 @@ packages:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   shelf_static:
     description:
       name: shelf_static
@@ -210,7 +210,7 @@ packages:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   source_map_stack_trace:
     description:
       name: source_map_stack_trace
@@ -234,13 +234,13 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   stream_channel:
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.1"
+    version: "1.6.2"
   string_scanner:
     description:
       name: string_scanner
@@ -258,13 +258,13 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.24+2"
+    version: "0.12.24+8"
   typed_data:
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.4"
+    version: "1.1.5"
   utf:
     description:
       name: utf
@@ -276,18 +276,18 @@ packages:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+3"
+    version: "0.9.7+4"
   web_socket_channel:
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.6"
   yaml:
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.12"
+    version: "2.1.13"
 sdks:
   dart: ">=1.23.0 <2.0.0-dev.infinity"

--- a/exercises/leap/pubspec.lock
+++ b/exercises/leap/pubspec.lock
@@ -6,13 +6,13 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.30.0+2"
+    version: "0.30.0+4"
   args:
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.7"
+    version: "1.0.0"
   async:
     description:
       name: async
@@ -24,7 +24,7 @@ packages:
       name: barback
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.2+11"
+    version: "0.15.2+12"
   boolean_selector:
     description:
       name: boolean_selector
@@ -42,7 +42,7 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.1.2+1"
   collection:
     description:
       name: collection
@@ -60,25 +60,25 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.2+1"
   csslib:
     description:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0"
+    version: "0.14.1"
   front_end:
     description:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-alpha.4"
+    version: "0.1.0-alpha.4.1"
   glob:
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.5"
   html:
     description:
       name: html
@@ -90,13 +90,13 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+14"
+    version: "0.11.3+15"
   http_multi_server:
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   http_parser:
     description:
       name: http_parser
@@ -108,7 +108,7 @@ packages:
       name: isolate
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   js:
     description:
       name: js
@@ -120,7 +120,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0-alpha.1"
+    version: "0.3.0-alpha.1.1"
   logging:
     description:
       name: logging
@@ -132,13 +132,13 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.1+2"
+    version: "0.12.1+4"
   meta:
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   mime:
     description:
       name: mime
@@ -156,7 +156,7 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   package_resolver:
     description:
       name: package_resolver
@@ -174,13 +174,13 @@ packages:
       name: plugin
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0+1"
+    version: "0.2.0+2"
   pool:
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   pub_semver:
     description:
       name: pub_semver
@@ -198,7 +198,7 @@ packages:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   shelf_static:
     description:
       name: shelf_static
@@ -210,7 +210,7 @@ packages:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   source_map_stack_trace:
     description:
       name: source_map_stack_trace
@@ -234,13 +234,13 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   stream_channel:
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.1"
+    version: "1.6.2"
   string_scanner:
     description:
       name: string_scanner
@@ -258,13 +258,13 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.24+2"
+    version: "0.12.24+8"
   typed_data:
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.4"
+    version: "1.1.5"
   utf:
     description:
       name: utf
@@ -276,18 +276,18 @@ packages:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+3"
+    version: "0.9.7+4"
   web_socket_channel:
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.6"
   yaml:
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.12"
+    version: "2.1.13"
 sdks:
   dart: ">=1.23.0 <2.0.0-dev.infinity"

--- a/exercises/rna-transcription/pubspec.lock
+++ b/exercises/rna-transcription/pubspec.lock
@@ -6,13 +6,13 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.30.0+2"
+    version: "0.30.0+4"
   args:
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.7"
+    version: "1.0.0"
   async:
     description:
       name: async
@@ -24,7 +24,7 @@ packages:
       name: barback
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.2+11"
+    version: "0.15.2+12"
   boolean_selector:
     description:
       name: boolean_selector
@@ -42,7 +42,7 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.1.2+1"
   collection:
     description:
       name: collection
@@ -60,25 +60,25 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.2+1"
   csslib:
     description:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0"
+    version: "0.14.1"
   front_end:
     description:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-alpha.4"
+    version: "0.1.0-alpha.4.1"
   glob:
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.5"
   html:
     description:
       name: html
@@ -90,13 +90,13 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+14"
+    version: "0.11.3+15"
   http_multi_server:
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   http_parser:
     description:
       name: http_parser
@@ -108,7 +108,7 @@ packages:
       name: isolate
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   js:
     description:
       name: js
@@ -120,7 +120,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0-alpha.1"
+    version: "0.3.0-alpha.1.1"
   logging:
     description:
       name: logging
@@ -132,13 +132,13 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.1+2"
+    version: "0.12.1+4"
   meta:
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   mime:
     description:
       name: mime
@@ -156,7 +156,7 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   package_resolver:
     description:
       name: package_resolver
@@ -174,13 +174,13 @@ packages:
       name: plugin
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0+1"
+    version: "0.2.0+2"
   pool:
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   pub_semver:
     description:
       name: pub_semver
@@ -198,7 +198,7 @@ packages:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   shelf_static:
     description:
       name: shelf_static
@@ -210,7 +210,7 @@ packages:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   source_map_stack_trace:
     description:
       name: source_map_stack_trace
@@ -234,13 +234,13 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   stream_channel:
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.1"
+    version: "1.6.2"
   string_scanner:
     description:
       name: string_scanner
@@ -258,13 +258,13 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.24+2"
+    version: "0.12.24+8"
   typed_data:
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.4"
+    version: "1.1.5"
   utf:
     description:
       name: utf
@@ -276,18 +276,18 @@ packages:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+3"
+    version: "0.9.7+4"
   web_socket_channel:
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.6"
   yaml:
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.12"
+    version: "2.1.13"
 sdks:
   dart: ">=1.23.0 <2.0.0-dev.infinity"

--- a/exercises/rna-transcription/test/rna_transcription_test.dart
+++ b/exercises/rna-transcription/test/rna_transcription_test.dart
@@ -10,7 +10,7 @@ void main() {
         final result = rnaTranscription.toRna("C");
 
         expect(result, equals("G"));
-      });
+      }, skip: false);
 
       test("transcribes guanine to cytosine", () {
         final result = rnaTranscription.toRna("G");

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -6,13 +6,13 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.30.0+2"
+    version: "0.30.0+4"
   args:
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.7"
+    version: "1.0.0"
   async:
     description:
       name: async
@@ -24,7 +24,7 @@ packages:
       name: barback
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.2+11"
+    version: "0.15.2+12"
   boolean_selector:
     description:
       name: boolean_selector
@@ -42,7 +42,7 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.1.2+1"
   collection:
     description:
       name: collection
@@ -60,31 +60,31 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.2+1"
   csslib:
     description:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0"
+    version: "0.14.1"
   dart_style:
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.7"
+    version: "1.0.8"
   front_end:
     description:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-alpha.4"
+    version: "0.1.0-alpha.4.1"
   glob:
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.5"
   html:
     description:
       name: html
@@ -96,13 +96,13 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+14"
+    version: "0.11.3+15"
   http_multi_server:
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   http_parser:
     description:
       name: http_parser
@@ -114,7 +114,7 @@ packages:
       name: isolate
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   js:
     description:
       name: js
@@ -126,7 +126,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0-alpha.1"
+    version: "0.3.0-alpha.1.1"
   logging:
     description:
       name: logging
@@ -138,13 +138,13 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.1+3"
+    version: "0.12.1+4"
   meta:
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   mime:
     description:
       name: mime
@@ -162,7 +162,7 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   package_resolver:
     description:
       name: package_resolver
@@ -180,13 +180,13 @@ packages:
       name: plugin
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0+1"
+    version: "0.2.0+2"
   pool:
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   pub_semver:
     description:
       name: pub_semver
@@ -204,7 +204,7 @@ packages:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   shelf_static:
     description:
       name: shelf_static
@@ -216,7 +216,7 @@ packages:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   source_map_stack_trace:
     description:
       name: source_map_stack_trace
@@ -240,13 +240,13 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   stream_channel:
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.1"
+    version: "1.6.2"
   string_scanner:
     description:
       name: string_scanner
@@ -264,13 +264,13 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.24+4"
+    version: "0.12.24+8"
   typed_data:
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.4"
+    version: "1.1.5"
   utf:
     description:
       name: utf
@@ -282,18 +282,18 @@ packages:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+3"
+    version: "0.9.7+4"
   web_socket_channel:
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.6"
   yaml:
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.12"
+    version: "2.1.13"
 sdks:
   dart: ">=1.23.0 <2.0.0-dev.infinity"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -12,7 +12,7 @@ packages:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "0.13.7"
   async:
     description:
       name: async

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,13 +42,13 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1"
+    version: "0.1.2"
   collection:
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.1"
+    version: "1.14.3"
   convert:
     description:
       name: convert
@@ -60,7 +60,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   csslib:
     description:
       name: csslib
@@ -72,7 +72,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.6"
+    version: "1.0.7"
   front_end:
     description:
       name: front_end
@@ -96,7 +96,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+13"
+    version: "0.11.3+14"
   http_multi_server:
     description:
       name: http_multi_server
@@ -115,6 +115,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  js:
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.1"
   kernel:
     description:
       name: kernel
@@ -132,25 +138,31 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.1+1"
+    version: "0.12.1+2"
   meta:
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.1"
   mime:
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.3"
+  node_preamble:
+    description:
+      name: node_preamble
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.4.0"
   package_config:
     description:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   package_resolver:
     description:
       name: package_resolver
@@ -168,7 +180,7 @@ packages:
       name: plugin
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.0+1"
   pool:
     description:
       name: pool
@@ -186,19 +198,19 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.8"
+    version: "0.7.0"
   shelf_packages_handler:
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.2"
   shelf_static:
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.4"
+    version: "0.2.5"
   shelf_web_socket:
     description:
       name: shelf_web_socket
@@ -228,7 +240,7 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.3"
+    version: "1.8.0"
   stream_channel:
     description:
       name: stream_channel
@@ -252,13 +264,13 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.23+1"
+    version: "0.12.24+2"
   typed_data:
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.4"
   utf:
     description:
       name: utf
@@ -276,7 +288,7 @@ packages:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   yaml:
     description:
       name: yaml
@@ -284,4 +296,4 @@ packages:
     source: hosted
     version: "2.1.12"
 sdks:
-  dart: ">=1.23.0 <2.0.0"
+  dart: ">=1.23.0 <2.0.0-dev.infinity"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -138,7 +138,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.1+2"
+    version: "0.12.1+3"
   meta:
     description:
       name: meta
@@ -264,7 +264,7 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.24+2"
+    version: "0.12.24+4"
   typed_data:
     description:
       name: typed_data

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,6 @@ name: exercism_dart
 authors:
   - SuperPaintman <SuperPaintmanDeveloper@gmail.com>
 dev_dependencies:
-  test: '0.12.23+1'
-  args: '0.13.7'
-  yaml: '2.1.12'
-  dart_style: '1.0.6'
+  test: '<0.13.0'
+  yaml: '>=2.1.12 <2.2.0'
+  dart_style: '^1.0.6'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,6 @@ name: exercism_dart
 authors:
   - SuperPaintman <SuperPaintmanDeveloper@gmail.com>
 dev_dependencies:
-  test: '<0.13.0'
+  dart_style: '>=1.0.8 <2.0.0'
+  test: '>=0.12.24+8 <0.13.0'
   yaml: '>=2.1.12 <2.2.0'
-  dart_style: '^1.0.6'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,7 @@ name: exercism_dart
 authors:
   - SuperPaintman <SuperPaintmanDeveloper@gmail.com>
 dev_dependencies:
+  args: '0.13.7'
   dart_style: '>=1.0.8 <2.0.0'
   test: '>=0.12.24+8 <0.13.0'
   yaml: '>=2.1.12 <2.2.0'

--- a/test/exercises_test.dart
+++ b/test/exercises_test.dart
@@ -64,10 +64,17 @@ Running tests for: $packageName
   await runCmd(["cp", "test/${packageName}_test.dart", "test/${packageName}_test.dart.bu"]);
   try {
     for (dynamic cmds in [
-      ["cp", "lib/example.dart", "lib/${packageName}.dart"], // Replace main file with example
-      ["sed", "-i", "-e", "s/\\bskip:\\s*true\\b/skip: false/g", "test/${packageName}_test.dart"], // Enable all tests
-      ["pub", "get"], // Pull dependencies
-      ["pub", "run", "test"] // Run tests
+      /// Replace main file with example
+      ["cp", "lib/example.dart", "lib/${packageName}.dart"],
+
+      /// Enable all tests
+      ["sed", "-i", "-e", "s/\\bskip:\\s*true\\b/skip: false/g", "test/${packageName}_test.dart"],
+
+      /// Pull dependencies
+      ["pub", "get"],
+
+      /// Run tests
+      ["pub", "run", "test"]
     ]) {
       await runCmd(cmds);
     }
@@ -96,7 +103,6 @@ Future runAllTests() async {
 Running tests for: $packageName
 ================================================================================
 """);
-
 }
 
 void main() {

--- a/test/exercises_test.dart
+++ b/test/exercises_test.dart
@@ -27,7 +27,7 @@ Future runCmd(List<String> cmds) async {
   assert(res.exitCode == 0);
 }
 
-Future getPackageName() async {
+Future<String> getPackageName() async {
   final pubspec = new File("pubspec.yaml");
 
   final packageName = loadYaml(await pubspec.readAsString())["name"];
@@ -46,7 +46,7 @@ Future locateExercismDirAndExecuteTests() async {
   final sortedExerciseDirs = exercisesDirs.toList();
   sortedExerciseDirs.sort((a, b) => a.path.compareTo(b.path));
 
-  for (dynamic dir in sortedExerciseDirs) {
+  for (FileSystemEntity dir in sortedExerciseDirs) {
     await runTest(dir.path);
   }
 }
@@ -57,7 +57,7 @@ Future runTest(String path) async {
 
   Directory.current = path;
 
-  dynamic packageName = await getPackageName();
+  String packageName = await getPackageName();
 
   print("""
 ================================================================================
@@ -68,7 +68,7 @@ Running tests for: $packageName
   await runCmd(["cp", "lib/${packageName}.dart", "lib/${packageName}.dart.bu"]);
   await runCmd(["cp", "test/${packageName}_test.dart", "test/${packageName}_test.dart.bu"]);
   try {
-    for (dynamic cmds in [
+    for (List<String> cmds in [
       /// Replace main file with example
       ["cp", "lib/example.dart", "lib/${packageName}.dart"],
 
@@ -101,7 +101,7 @@ Future runAllTests() async {
 
   Directory.current = dartExercismRootDir.parent;
 
-  dynamic packageName = await getPackageName();
+  String packageName = await getPackageName();
 
   print("""
 

--- a/test/exercises_test.dart
+++ b/test/exercises_test.dart
@@ -42,11 +42,16 @@ Future locateExercismDirAndExecuteTests() async {
 
   final exercisesDirs = exercisesRootDir.listSync().where((d) => d is Directory);
 
-  for (dynamic dir in exercisesDirs) {
+  /// Sort directories alphabetically
+  final sortedExerciseDirs = exercisesDirs.toList();
+  sortedExerciseDirs.sort((a, b) => a.path.compareTo(b.path));
+
+  for (dynamic dir in sortedExerciseDirs) {
     await runTest(dir.path);
   }
 }
 
+/// Execute a single test
 Future runTest(String path) async {
   final current = Directory.current;
 
@@ -86,6 +91,7 @@ Running tests for: $packageName
   }
 }
 
+/// Execute all the tests under the exercise directory
 Future runAllTests() async {
   final dartExercismRootDir = new Directory("..");
 


### PR DESCRIPTION
Implementation of #34. Add a command to travis to run the tests.

@SuperPaintman already had a script to run all tests. But since that was also a test, the final results were not separated from the test results of the last exercise. So I added a statement in between.

Additionally updated the repo's package dependencies to reflect the changes to versioning we made for the exercises.

***Note to Reviewer***: No changes to Travis Settings requested