### PR TITLE
Some Test suites accidentally reference the example.dart file

### DIFF
--- a/exercises/anagram/test/anagram_test.dart
+++ b/exercises/anagram/test/anagram_test.dart
@@ -1,5 +1,5 @@
 import 'package:test/test.dart';
-import 'package:anagram/example.dart';
+import 'package:anagram/anagram.dart';
 
 Anagram anagram = new Anagram();
 

--- a/exercises/rna-transcription/test/rna_transcription_test.dart
+++ b/exercises/rna-transcription/test/rna_transcription_test.dart
@@ -1,5 +1,5 @@
 import "package:test/test.dart";
-import "package:rna_transcription/example.dart";
+import "package:rna_transcription/rna_transcription.dart";
 
 void main() {
   final rnaTranscription = new RnaTranscription();


### PR DESCRIPTION
Two test suites are referencing "example.dart" which is the solution to the given problem. Nothing is leaked to the user, because the file is not included when users fetch the problem.

But we shouldn't include errors into our user's test suites, so we should remove it.

@exercism/dart or @fwip care to check me over?