### PR TITLE
Generate tests

### DIFF
--- a/tool/create-exercise
+++ b/tool/create-exercise
@@ -179,10 +179,18 @@ Future main(args) async {
 
   // Get test cases from canonical-data.json, format tests
   if (arguments["spec-path"] != null) {
-    var file = new File("${arguments['spec-path']}/exercises/$name/canonical-data.json");
-    final specification = JSON.decode(await file.readAsString());
-
-    testCasesString = testCaseTemplate(name, specification);
+    String filename = "${arguments['spec-path']}/exercises/$name/canonical-data.json";
+    try {
+      File file = new File(filename);
+      final specification = JSON.decode(await file.readAsString());
+      testCasesString = testCaseTemplate(name, specification);
+    } on FileSystemException {
+      stderr.write("Could not open file '$filename', exiting.\n");
+      exit(1);
+    } on FormatException {
+      stderr.write("File '$filename' is not valid JSON, exiting.\n");
+      exit(1);
+    }
   }
 
   if (await exerciseDir.exists()) {

--- a/tool/create-exercise
+++ b/tool/create-exercise
@@ -122,25 +122,31 @@ String repr(dynamic x) {
     x = x.replaceAll("\n", r"\n").replaceAll(r"$", r"\$");
     return '"$x"';
   }
+
   if (x is Iterable) {
     return '[${x.map(repr).join(", ")}]';
   }
+
   if (x is Map) {
     List<String> pairs = [];
     for (var k in x.keys) {
       pairs.add("${repr(k)}: ${repr(x[k])}");
     }
+
     return "{${pairs.join(', ')}}";
   }
+
   return "$x";
 }
 
 /// A helper method to get the inside type of an iterable
 String getIterableType(dynamic iter) {
   Set<String> types = iter.map(getFriendlyType).toSet();
+
   if (types.length == 1) {
     return types.first;
   }
+
   return "dynamic";
 }
 
@@ -149,15 +155,19 @@ String getFriendlyType(dynamic x) {
   if (x is String) {
     return "String";
   }
+
   if (x is Iterable) {
     return "List<${getIterableType(x)}>";
   }
+
   if (x is Map) {
     return "Map<${getIterableType(x.keys)}, ${getIterableType(x.values)}>";
   }
+
   if (x is num) {
     return "num";
   }
+
   return x.runtimeType;
 }
 

--- a/tool/create-exercise
+++ b/tool/create-exercise
@@ -81,11 +81,18 @@ dev_dependencies:
   test: '<0.13.0'
 """;
 
-String testCaseTemplate(name, testCase) {
+String testCaseTemplate(String name, Map<String, Object> testCase, {bool firstTest = true}) {
   if (testCase['cases'] != null) {
     // We have a group, not a case
-    String tests = testCase['cases'].map((c) => testCaseTemplate(name, c)).join("\n");
     String description = testCase['description'];
+
+    // Build the tests up recursively, only first test should be skipped
+    List<String> testList = [];
+    for (Map<String, Object> c in testCase['cases']) {
+      testList.add(testCaseTemplate(name, c, firstTest: firstTest));
+      firstTest = false;
+    }
+    String tests = testList.join("\n");
 
     if (description == null) {
       return tests;
@@ -111,7 +118,7 @@ String testCaseTemplate(name, testCase) {
     test($description, () {
       final $resultType result = $object.$method($arguments);
       expect(result, equals($expected));
-    }, skip: true);
+    }, skip: ${!firstTest});
   """;
 }
 

--- a/tool/create-exercise
+++ b/tool/create-exercise
@@ -238,6 +238,9 @@ Future main(args) async {
 
     if (res.exitCode != 0) {
       stderr.write("Warning: dartfmt exited with a code of ${res.exitCode}, '$testFileName' is likely malformed.\n");
+    } else {
+      stdout.write("Successfully created a rough-draft of tests at '$testFileName'.\n");
+      stdout.write("You should check this over and fix or refine as necessary.\n");
     }
   }
 

--- a/tool/create-exercise
+++ b/tool/create-exercise
@@ -117,7 +117,7 @@ String testCaseTemplate(name, testCase) {
 
 /// `repr` takes in any object and tries to coerce it to a String in such a way that it is suitable to include in code.
 /// Based on the python `repr` function, but only works for basic types: String, Iterable, Map, and primitive types
-String repr(dynamic x) {
+String repr(Object x) {
   if (x is String) {
     x = x.replaceAll("\n", r"\n").replaceAll(r"$", r"\$");
     return '"$x"';
@@ -140,18 +140,18 @@ String repr(dynamic x) {
 }
 
 /// A helper method to get the inside type of an iterable
-String getIterableType(dynamic iter) {
+String getIterableType(Object iter) {
   Set<String> types = iter.map(getFriendlyType).toSet();
 
   if (types.length == 1) {
     return types.first;
   }
 
-  return "dynamic";
+  return "Object";
 }
 
 /// Get a human-friendly type of a variable
-String getFriendlyType(dynamic x) {
+String getFriendlyType(Object x) {
   if (x is String) {
     return "String";
   }

--- a/tool/create-exercise
+++ b/tool/create-exercise
@@ -212,14 +212,26 @@ Future main(args) async {
   await new Directory("${exerciseDir.path}/test").create(recursive: true);
 
   // Create files
+  String testFileName = "${exerciseDir.path}/test/${filename}_test.dart";
   await new File("${exerciseDir.path}/lib/example.dart").writeAsString(exampleTemplate(name));
   await new File("${exerciseDir.path}/lib/${filename}.dart").writeAsString(mainTemplate(name));
-  await new File("${exerciseDir.path}/test/${filename}_test.dart").writeAsString(testTemplate(name));
+  await new File(testFileName).writeAsString(testTemplate(name));
   await new File("${exerciseDir.path}/pubspec.yaml").writeAsString(pubTemplate(name));
 
   if (arguments["spec-path"] != null) {
     // The output from test generation is not always well-formatted, use dartfmt to clean it up
-    await Process.run("dartfmt", ["-l", "120", "-w", "${exerciseDir.path}/test/${filename}_test.dart"]);
+    final res = await Process.run("dartfmt", ["-l", "120", "-w", testFileName], runInShell: true);
+    if (!res.stdout.toString().isEmpty) {
+      stdout.write(res.stdout);
+    }
+
+    if (!res.stderr.toString().isEmpty) {
+      stderr.write(res.stderr);
+    }
+
+    if (res.exitCode != 0) {
+      stderr.write("Warning: dartfmt exited with a code of ${res.exitCode}, '$testFileName' is likely malformed.\n");
+    }
   }
 
   // Install deps

--- a/tool/create-exercise
+++ b/tool/create-exercise
@@ -207,6 +207,11 @@ Future main(args) async {
   await new File("${exerciseDir.path}/test/${filename}_test.dart").writeAsString(testTemplate(name));
   await new File("${exerciseDir.path}/pubspec.yaml").writeAsString(pubTemplate(name));
 
+  if (arguments["spec-path"] != null) {
+    // The output from test generation is not always well-formatted, use dartfmt to clean it up
+    await Process.run("dartfmt", ["-l", "120", "-w", "${exerciseDir.path}/test/${filename}_test.dart"]);
+  }
+
   // Install deps
   Directory.current = exerciseDir;
 

--- a/tool/create-exercise
+++ b/tool/create-exercise
@@ -3,12 +3,15 @@
 
 import "dart:io";
 import "dart:async";
+import "dart:convert";
 import "package:args/args.dart";
 
 /** Constants */
 const ME = "create-exercise";
 
-final parser = new ArgParser()..addSeparator("Usage: $ME <slug>");
+final parser = new ArgParser()
+  ..addSeparator("Usage: $ME <slug> [--spec-path path]")
+  ..addOption("spec-path", help: "The location of the problem-specifications directory.", valueHelp: 'path');
 
 /** Helpers */
 List<String> words(String str) {
@@ -54,6 +57,11 @@ class ${pascalCase(name)} {
 }
 """;
 
+String testCasesString = """
+    test("should work", () {
+      // TODO
+    });""";
+
 String testTemplate(String name) => """
 import "package:test/test.dart";
 import "package:${snakeCase(name)}/${snakeCase(name)}.dart";
@@ -62,9 +70,7 @@ void main() {
   final ${camelCase(name)} = new ${pascalCase(name)}();
 
   group("${pascalCase(name)}", () {
-    test("should work", () {
-      // TODO
-    });
+$testCasesString
   });
 }
 """;
@@ -74,6 +80,86 @@ name: '${snakeCase(name)}'
 dev_dependencies:
   test: '<0.13.0'
 """;
+
+String testCaseTemplate(name, testCase) {
+  if (testCase['cases'] != null) {
+    // We have a group, not a case
+    String tests = testCase['cases'].map((c) => testCaseTemplate(name, c)).join("\n");
+    String description = testCase['description'];
+
+    if (description == null) {
+      return tests;
+    }
+
+    return """
+      group("$description", () {
+        $tests
+      });
+    """;
+  }
+
+  String description = repr(testCase['description']);
+  String resultType = getFriendlyType(testCase['expected']);
+  String object = camelCase(name);
+  String method = camelCase(testCase['property']);
+  String expected = repr(testCase['expected']);
+
+  List<String> inputKeys = testCase.keys.toList()..remove("expected")..remove("description")..remove("property");
+  String arguments = inputKeys.map((k) => repr(testCase[k])).join(", ");
+
+  return """
+    test($description, () {
+      final $resultType result = $object.$method($arguments);
+      expect(result, equals($expected));
+    }, skip: true);
+  """;
+}
+
+/// `repr` takes in any object and tries to coerce it to a String in such a way that it is suitable to include in code.
+/// Based on the python `repr` function, but only works for basic types: String, Iterable, Map, and primitive types
+String repr(dynamic x) {
+  if (x is String) {
+    x = x.replaceAll("\n", r"\n").replaceAll(r"$", r"\$");
+    return '"$x"';
+  }
+  if (x is Iterable) {
+    return '[${x.map(repr).join(", ")}]';
+  }
+  if (x is Map) {
+    List<String> pairs = [];
+    for (var k in x.keys) {
+      pairs.add("${repr(k)}: ${repr(x[k])}");
+    }
+    return "{${pairs.join(', ')}}";
+  }
+  return "$x";
+}
+
+/// A helper method to get the inside type of an iterable
+String getIterableType(dynamic iter) {
+  Set<String> types = iter.map(getFriendlyType).toSet();
+  if (types.length == 1) {
+    return types.first;
+  }
+  return "dynamic";
+}
+
+/// Get a human-friendly type of a variable
+String getFriendlyType(dynamic x) {
+  if (x is String) {
+    return "String";
+  }
+  if (x is Iterable) {
+    return "List<${getIterableType(x)}>";
+  }
+  if (x is Map) {
+    return "Map<${getIterableType(x.keys)}, ${getIterableType(x.values)}>";
+  }
+  if (x is num) {
+    return "num";
+  }
+  return x.runtimeType;
+}
 
 Future main(args) async {
   final arguments = parser.parse(args);
@@ -90,6 +176,14 @@ Future main(args) async {
   final currentDir = Directory.current;
   final exerciseDir = new Directory("exercises/${kebabCase(name)}");
   final filename = snakeCase(name);
+
+  // Get test cases from canonical-data.json, format tests
+  if (arguments["spec-path"] != null) {
+    var file = new File("${arguments['spec-path']}/exercises/$name/canonical-data.json");
+    final specification = JSON.decode(await file.readAsString());
+
+    testCasesString = testCaseTemplate(name, specification);
+  }
 
   if (await exerciseDir.exists()) {
     stderr.write("$name already exist");

--- a/tool/create-exercise
+++ b/tool/create-exercise
@@ -119,7 +119,7 @@ String testCaseTemplate(name, testCase) {
 /// Based on the python `repr` function, but only works for basic types: String, Iterable, Map, and primitive types
 String repr(Object x) {
   if (x is String) {
-    x = x.replaceAll("\n", r"\n").replaceAll(r"$", r"\$");
+    x = x.replaceAll('"', r'\"').replaceAll("\n", r"\n").replaceAll(r"$", r"\$");
     return '"$x"';
   }
 


### PR DESCRIPTION
This pull request adds a `--spec-path` argument to `tool/create-exercise`. If given a path to a checkout of https://github.com/exercism/problem-specifications , it will use the information in `canonical-data.json` to generate tests.  (I chose `--spec-path` after the option in `bin/configlet generate`).

Example usage:
`dart tool/create-exercise --spec-path ../problem-specifications/ beer-song`

It doesn't work for every `canonical-data.json` out there, and some others will need some light editing to get into the proper format.  But it could be useful if we're trying to crank out a bunch of regular-ish exercises.

What do you think @Stargator ?