### PR TITLE
Make Anagram a core track

### DIFF
--- a/config.json
+++ b/config.json
@@ -113,7 +113,7 @@
       "uuid": "99147c39-e8d3-4166-9215-c47fb4832781"
     },
     {
-      "core": false,
+      "core": true,
       "difficulty": 1,
       "slug": "anagram",
       "topics": [


### PR DESCRIPTION
Apparently, I had a few typos. @fwip fixed the unlocked value and I never noticed the "core" parameter was false. So resolving that.