### PR TITLE
Fix invalid exercise UUID

### DIFF
--- a/config.json
+++ b/config.json
@@ -111,7 +111,7 @@
         "strings"
       ],
       "unlocked_by": "gigasecond",
-      "uuid": "d6657d4a-0257-0c80-6667-fddd127a571f0ad1fd4"
+      "uuid": "3d4e326d-2419-4e93-ac29-5727dbc3fbf1"
     },
     {
       "core": true,


### PR DESCRIPTION
The previous version of `configlet uuid` was known to generate invalid UUIDs. The latest release of Configlet [v3.6.1](https://github.com/exercism/configlet/releases) fixes that issue for newly added exercises, but existing exercise UUIDs need to be updated manually.

This change pertains to exercism/configlet#99