### PR TITLE
leap: add more test cases

### DIFF
--- a/exercises/leap/test/leap_test.dart
+++ b/exercises/leap/test/leap_test.dart
@@ -24,5 +24,20 @@ void main() {
       final bool result = leap.leapYear(2000);
       expect(result, equals(true));
     }, skip: true);
+
+    test("is introduced every 4 years to adjust about a day before 400 A.D.", () {
+      final bool result = leap.leapYear(4);
+      expect(result, equals(true));
+    }, skip: true);
+
+    test("is skipped every 100 years to remove an extra day before 400 A.D.", () {
+      final bool result = leap.leapYear(300);
+      expect(result, equals(false));
+    }, skip: true);
+
+    test("is reintroduced every 400 years to adjust another day including 400 A.D.", () {
+      final bool result = leap.leapYear(400);
+      expect(result, equals(true));
+    }, skip: true);
   });
 }


### PR DESCRIPTION
I added more test cases to account for dates less than 400 years old. I also wasn't sure why `skip: true` was being set on every test so I removed those.