### PR TITLE
dart-exercism: Fix formatting and dependency issues

### DIFF
--- a/exercises/armstrong-numbers/lib/example.dart
+++ b/exercises/armstrong-numbers/lib/example.dart
@@ -1,7 +1,6 @@
 import 'dart:math' show pow;
 
 class ArmstrongNumbers {
-
   /// The parameters and variables within the method that are set to final in order to prevent the accidentally modification of the value.
   /// As those variables are not needed to be changed.
   bool isArmstrongNumber(final int number) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -114,7 +114,7 @@ packages:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.2+1"
+    version: "0.3.0"
   isolate:
     description:
       name: isolate


### PR DESCRIPTION
The dependency in the pubspec.lock file is off and there's a formatting issue in armstrong-numbers.

Addressing these minor issues will help by preventing false negatives and making it easier to run the tests without running `pub get`