### PR TITLE
Update maintainer username

### DIFF
--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -32,7 +32,7 @@
       "bio": null
     },
     {
-      "github_username": "kabiir",
+      "github_username": "devkabiir",
       "alumnus": false,
       "show_on_website": true,
       "name": null,


### PR DESCRIPTION
@kabiir changed their username to @devkabiir.
We rely on the correct username to get the data for the maintainers
page, and to link to the GitHub profile.

FYI @Stargator - I'm merging this, as it's breaking a script that we're running regularly.