### PR TITLE
Compensate when tests are executed on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Exercism exercises in Dart.
 
 ## Setup
 
+### Requirements
+ * Dart (Between 1.23.0 and 2.0.0)
+ * `sed` command (For Mac Users: `brew install gnu-sed --with-default-names`)
+
 The simplest way to install Dart can be [found here](docs/INSTALLATION.md).
 
 Clone the repo and run `pub get` to download all the dependencies for this project.

--- a/test/exercises_test.dart
+++ b/test/exercises_test.dart
@@ -68,12 +68,15 @@ Running tests for: $packageName
   await runCmd(["cp", "lib/${packageName}.dart", "lib/${packageName}.dart.bu"]);
   await runCmd(["cp", "test/${packageName}_test.dart", "test/${packageName}_test.dart.bu"]);
   try {
+
+    String inPlaceOption = Platform.isMacOS ? "--in-place" : "-i";
+
     for (List<String> cmds in [
       /// Replace main file with example
       ["cp", "lib/example.dart", "lib/${packageName}.dart"],
 
       /// Enable all tests
-      ["sed", "-i", "-e", "s/\\bskip:\\s*true\\b/skip: false/g", "test/${packageName}_test.dart"],
+      ["sed", inPlaceOption, "-e", "s/\\bskip:\\s*true\\b/skip: false/g", "test/${packageName}_test.dart"],
 
       /// Pull dependencies
       ["pub", "get"],


### PR DESCRIPTION
I don't have a Windows machine to run the tests on, so I cannot verify that `pub run test` works in Windows.

I have noticed that MacOS was producing files with "-e" or "e" appended to the extension, so I resolved that.