### PR TITLE
Add 'math' topic to relevant exercises in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -53,6 +53,7 @@
         "equality",
         "integers",
         "logic",
+        "math",
         "strings"
       ]
     },
@@ -64,7 +65,7 @@
       "difficulty": 2,
       "topics": [
         "integers",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -127,7 +128,6 @@
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
-        "mathematics",
         "time"
       ]
     },
@@ -140,7 +140,6 @@
       "topics": [
         "control_flow_conditionals",
         "equality",
-        "mathematics",
         "strings"
       ]
     },


### PR DESCRIPTION
The new site lets people filter optional exercises by topic, and this
makes it easy for people to skip past them.

This is important since the math-y exercises are not key to learning
the language, and a lot of people find them intimidating and demotivating.

This updates any 'mathematics' topics to be 'math' since it's shorter
and won't get cropped in the UI.

It also removes the math topics for any exercises that are not in the
canonical math-y list.


exercism/exercism.io#4110