### PR TITLE
Updated links to help resources

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -11,7 +11,7 @@ To run the tests:
 $ pub run test
 ```
 
-For more detailed info about the Dart track see the [help page](http://exercism.io/languages/dart).
+For more detailed info about the Dart track see the [installation](http://exercism.io/languages/dart/installation) and [testing](http://exercism.io/languages/dart/tests) pages.
 {{ with .Spec.Credits }}
 ## Source
 

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -13,7 +13,7 @@ To run the tests:
 $ pub run test
 ```
 
-For more detailed info about the Dart track see the [help page](http://exercism.io/languages/dart).
+For more detailed info about the Dart track see the [installation](http://exercism.io/languages/dart/installation) and [testing](http://exercism.io/languages/dart/tests) pages.
 
 ## Source
 

--- a/exercises/armstrong-numbers/README.md
+++ b/exercises/armstrong-numbers/README.md
@@ -18,8 +18,7 @@ To run the tests:
 $ pub run test
 ```
 
-For more detailed info about the Dart track see the [help page](http://exercism.io/languages/dart).
-
+For more detailed info about the Dart track see the [installation](http://exercism.io/languages/dart/installation) and [testing](http://exercism.io/languages/dart/tests) pages.
 
 ## Source
 

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -20,7 +20,7 @@ To run the tests:
 $ pub run test
 ```
 
-For more detailed info about the Dart track see the [help page](http://exercism.io/languages/dart).
+For more detailed info about the Dart track see the [installation](http://exercism.io/languages/dart/installation) and [testing](http://exercism.io/languages/dart/tests) pages.
 
 ## Source
 

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -19,7 +19,7 @@ To run the tests:
 $ pub run test
 ```
 
-For more detailed info about the Dart track see the [help page](http://exercism.io/languages/dart).
+For more detailed info about the Dart track see the [installation](http://exercism.io/languages/dart/installation) and [testing](http://exercism.io/languages/dart/tests) pages.
 
 ## Source
 

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -11,7 +11,7 @@ To run the tests:
 $ pub run test
 ```
 
-For more detailed info about the Dart track see the [help page](http://exercism.io/languages/dart).
+For more detailed info about the Dart track see the [installation](http://exercism.io/languages/dart/installation) and [testing](http://exercism.io/languages/dart/tests) pages.
 
 ## Source
 

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -42,7 +42,7 @@ To run the tests:
 $ pub run test
 ```
 
-For more detailed info about the Dart track see the [help page](http://exercism.io/languages/dart).
+For more detailed info about the Dart track see the [installation](http://exercism.io/languages/dart/installation) and [testing](http://exercism.io/languages/dart/tests) pages.
 
 ## Source
 

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -21,7 +21,7 @@ To run the tests:
 $ pub run test
 ```
 
-For more detailed info about the Dart track see the [help page](http://exercism.io/languages/dart).
+For more detailed info about the Dart track see the [installation](http://exercism.io/languages/dart/installation) and [testing](http://exercism.io/languages/dart/tests) pages.
 
 ## Source
 

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -33,7 +33,7 @@ To run the tests:
 $ pub run test
 ```
 
-For more detailed info about the Dart track see the [help page](http://exercism.io/languages/dart).
+For more detailed info about the Dart track see the [installation](http://exercism.io/languages/dart/installation) and [testing](http://exercism.io/languages/dart/tests) pages.
 
 ## Source
 

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -61,7 +61,7 @@ To run the tests:
 $ pub run test
 ```
 
-For more detailed info about the Dart track see the [help page](http://exercism.io/languages/dart).
+For more detailed info about the Dart track see the [installation](http://exercism.io/languages/dart/installation) and [testing](http://exercism.io/languages/dart/tests) pages.
 
 ## Source
 

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -24,7 +24,7 @@ To run the tests:
 $ pub run test
 ```
 
-For more detailed info about the Dart track see the [help page](http://exercism.io/languages/dart).
+For more detailed info about the Dart track see the [installation](http://exercism.io/languages/dart/installation) and [testing](http://exercism.io/languages/dart/tests) pages.
 
 ## Source
 

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -25,7 +25,7 @@ To run the tests:
 $ pub run test
 ```
 
-For more detailed info about the Dart track see the [help page](http://exercism.io/languages/dart).
+For more detailed info about the Dart track see the [installation](http://exercism.io/languages/dart/installation) and [testing](http://exercism.io/languages/dart/tests) pages.
 
 ## Source
 

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -45,7 +45,7 @@ To run the tests:
 $ pub run test
 ```
 
-For more detailed info about the Dart track see the [help page](http://exercism.io/languages/dart).
+For more detailed info about the Dart track see the [installation](http://exercism.io/languages/dart/installation) and [testing](http://exercism.io/languages/dart/tests) pages.
 
 ## Source
 

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -18,7 +18,7 @@ To run the tests:
 $ pub run test
 ```
 
-For more detailed info about the Dart track see the [help page](http://exercism.io/languages/dart).
+For more detailed info about the Dart track see the [installation](http://exercism.io/languages/dart/installation) and [testing](http://exercism.io/languages/dart/tests) pages.
 
 ## Source
 


### PR DESCRIPTION
Changed help links to point directly to the documentation pages - I've included the two most important pages, and other pages can be found on the bottom of the doc pages or via the bottom right of solution pages.

Fixes #143 