### PR TITLE
exercism/dart:  Address Dart analyzer errors due to Dart 2.0 strong typing

### DIFF
--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 import "dart:io";
+
 import "package:args/args.dart";
 import "package:dart2_constant/convert.dart" as polyfill;
 import "package:path/path.dart" show dirname;
@@ -111,11 +112,11 @@ String testCaseTemplate(String name, Map<String, Object> testCase, {bool firstTe
 
   if (testCase['cases'] != null) {
     // We have a group, not a case
-    String description = testCase['description'];
+    String description = testCase['description'] as String;
 
     // Build the tests up recursively, only first test should be skipped
     List<String> testList = <String>[];
-    for (Map<String, Object> caseObj in testCase['cases']) {
+    for (Map<String, Object> caseObj in testCase['cases'] as dynamic) {
       testList.add(testCaseTemplate(name, caseObj, firstTest: skipTests));
       skipTests = false;
     }
@@ -242,7 +243,7 @@ Future main(List<String> args) async {
     try {
       final File canonicalDataJson = new File(filename);
       final source = await canonicalDataJson.readAsString();
-      final Map<String, Object> specification = polyfill.json.decode(source);
+      final Map<String, Object> specification = polyfill.json.decode(source) as Map<String, Object>;
 
       testCasesString = testCaseTemplate(name, specification);
       print("Found: ${arguments['spec-path']}/exercises/$name/canonical-data.json");

--- a/test/exercises_test.dart
+++ b/test/exercises_test.dart
@@ -1,5 +1,5 @@
-import "dart:io";
 import "dart:async";
+import "dart:io";
 
 import "package:test/test.dart";
 import "package:yaml/yaml.dart";
@@ -30,7 +30,7 @@ Future<String> getPackageName() async {
 
   final String pubspecString = await pubspec.readAsString();
 
-  final String packageName = loadYaml(pubspecString)["name"];
+  final String packageName = loadYaml(pubspecString)["name"] as String;
 
   return packageName;
 }
@@ -74,7 +74,7 @@ Running tests for: $packageName
 
     for (List<String> cmds in [
       /// Pull dependencies
-      ["pub", "get"],
+      ["pub", "upgrade"],
 
       /// Run all exercise tests
       ["pub", "run", "test", "--run-skipped"]


### PR DESCRIPTION
The Dart Analyzer has been giving some errors when casting some variables or values.
They did not prevent the tests or other scripts from running successfully, but I still wanted to address them to prevent confusion.

I've addressed them and formatted the files I changed.

Additionally, I added the .dart_tool directory to the ignore file.