### PR TITLE
Update create exercise to handle more scenarios

### DIFF
--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -6,11 +6,11 @@ import 'package:args/args.dart';
 import 'package:path/path.dart' show dirname;
 
 /// Constants
-const String scriptFilename = "create-exercise";
+const String scriptFilename = 'create-exercise';
 
 final parser = new ArgParser()
-  ..addSeparator("Usage: $scriptFilename [--spec-path path] <slug>")
-  ..addOption("spec-path", help: "The location of the problem-specifications directory.", valueHelp: 'path');
+  ..addSeparator('Usage: $scriptFilename [--spec-path path] <slug>')
+  ..addOption('spec-path', help: 'The location of the problem-specifications directory.', valueHelp: 'path');
 
 /// Helpers
 List<String> words(final String str) {
@@ -18,19 +18,19 @@ List<String> words(final String str) {
 
   return str
       .toLowerCase()
-      .replaceAll(new RegExp(r"[^a-z0-9]"), " ")
-      .replaceAll(new RegExp(r" +"), " ")
+      .replaceAll(new RegExp(r'[^a-z0-9]'), ' ')
+      .replaceAll(new RegExp(r' +'), ' ')
       .trim()
-      .split(" ");
+      .split(' ');
 }
 
 String upperFirst(final String str) {
   if (str == null || str.length == 0) return '';
 
-  final chars = str.split("");
+  final chars = str.split('');
   final first = chars.first;
 
-  return first.toUpperCase() + chars.skip(1).join("");
+  return first.toUpperCase() + chars.skip(1).join('');
 }
 
 String camelCase(String str, {bool isUpperFirst = false}) {
@@ -38,40 +38,40 @@ String camelCase(String str, {bool isUpperFirst = false}) {
   final first = parts.first;
   final rest = parts.skip(1);
 
-  return (isUpperFirst ? upperFirst(first) : first) + rest.map(upperFirst).join("");
+  return (isUpperFirst ? upperFirst(first) : first) + rest.map(upperFirst).join('');
 }
 
 String pascalCase(String str) => camelCase(str, isUpperFirst: true);
 
-String snakeCase(String str) => words(str).join("_");
+String snakeCase(String str) => words(str).join('_');
 
-String kebabCase(String str) => words(str).join("-");
+String kebabCase(String str) => words(str).join('-');
 
 /// Templates
-String exampleTemplate(String name) => """
+String exampleTemplate(String name) => '''
 class ${pascalCase(name)} {
 
 }
-""";
+''';
 
-String mainTemplate(String name) => """
+String mainTemplate(String name) => '''
 class ${pascalCase(name)} {
   // Put your code here
 }
-""";
+''';
 
-String _testCasesString = """
+String _testCasesString = '''
     test('should work', () {
       // TODO
-    });""";
+    });''';
 
 /// The test template sorts the import of packages, instantiates an instance of the exercise class, and defines the main
 /// function's group of tests.
 String testTemplate(String name) {
-  final packages = <String>[name, "test"];
+  final packages = <String>[name, 'test'];
   packages.sort();
 
-  return """
+  return '''
 import 'package:${snakeCase(packages[0])}/${snakeCase(packages[0])}.dart';
 import 'package:${snakeCase(packages[1])}/${snakeCase(packages[1])}.dart';
 
@@ -82,18 +82,18 @@ void main() {
 $_testCasesString
   });
 }
-""";
+''';
 }
 
-String pubTemplate(String name) => """
+String pubTemplate(String name) => '''
 name: '${snakeCase(name)}'
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'
-""";
+''';
 
-String analysisOptionsTemplate() => """
+String analysisOptionsTemplate() => '''
 analyzer:
   strong-mode:
     implicit-casts: false
@@ -112,7 +112,7 @@ linter:
     - literal_only_boolean_expressions
     - no_adjacent_strings_in_list
     - valid_regexps
-""";
+''';
 
 String testCaseTemplate(String exerciseName, Map<String, Object> testCase, {bool firstTest = true, String returnType}) {
   bool skipTests = firstTest;
@@ -131,17 +131,17 @@ String testCaseTemplate(String exerciseName, Map<String, Object> testCase, {bool
       testList.add(testCaseTemplate(exerciseName, caseObj, firstTest: skipTests, returnType: returnType));
       skipTests = false;
     }
-    String tests = testList.join("\n");
+    String tests = testList.join('\n');
 
     if (description == null) {
       return tests;
     }
 
-    return """
+    return '''
       group('$description', () {
         $tests
       });
-    """;
+    ''';
   }
 
   String description = repr(testCase['description']);
@@ -191,51 +191,51 @@ Future<bool> _doGenerate(Directory exerciseDir, String exerciseName, String vers
 void _generateExercise(Map<String, Object> specification, String exerciseFilename, String exerciseName,
     Directory exerciseDir, String version, ArgResults arguments) async {
   _testCasesString = testCaseTemplate(exerciseName, specification);
-  print("Found: ${arguments['spec-path']}/exercises/$exerciseName/canonical-data.json");
+  print('Found: ${arguments['spec-path']}/exercises/$exerciseName/canonical-data.json');
 
-  await new Directory("${exerciseDir.path}/.meta").create(recursive: true);
-  await new Directory("${exerciseDir.path}/lib").create(recursive: true);
-  await new Directory("${exerciseDir.path}/test").create(recursive: true);
+  await new Directory('${exerciseDir.path}/.meta').create(recursive: true);
+  await new Directory('${exerciseDir.path}/lib').create(recursive: true);
+  await new Directory('${exerciseDir.path}/test').create(recursive: true);
 
   // Create files
-  String testFileName = "${exerciseDir.path}/test/${exerciseFilename}_test.dart";
+  String testFileName = '${exerciseDir.path}/test/${exerciseFilename}_test.dart';
   await new File('${exerciseDir.path}/.meta/version').writeAsString(version);
-  await new File("${exerciseDir.path}/lib/example.dart").writeAsString(exampleTemplate(exerciseName));
-  await new File("${exerciseDir.path}/lib/${exerciseFilename}.dart").writeAsString(mainTemplate(exerciseName));
+  await new File('${exerciseDir.path}/lib/example.dart').writeAsString(exampleTemplate(exerciseName));
+  await new File('${exerciseDir.path}/lib/${exerciseFilename}.dart').writeAsString(mainTemplate(exerciseName));
   await new File(testFileName).writeAsString(testTemplate(exerciseName));
-  await new File("${exerciseDir.path}/analysis_options.yaml").writeAsString(analysisOptionsTemplate());
-  await new File("${exerciseDir.path}/pubspec.yaml").writeAsString(pubTemplate(exerciseName));
+  await new File('${exerciseDir.path}/analysis_options.yaml').writeAsString(analysisOptionsTemplate());
+  await new File('${exerciseDir.path}/pubspec.yaml').writeAsString(pubTemplate(exerciseName));
 
   // Generate README
-  final dartRoot = "${dirname(Platform.script.toFilePath())}/..";
-  final configletLoc = "$dartRoot/bin/configlet";
+  final dartRoot = '${dirname(Platform.script.toFilePath())}/..';
+  final configletLoc = '$dartRoot/bin/configlet';
   final genSuccess = await runProcess(
-      configletLoc, ["generate", "$dartRoot", "--spec-path", '${arguments['spec-path']}', "--only", exerciseName]);
+      configletLoc, ['generate', '$dartRoot', '--spec-path', '${arguments['spec-path']}', '--only', exerciseName]);
   if (genSuccess) {
-    stdout.write("Successfully created README.md\n");
+    stdout.write('Successfully created README.md\n');
   } else {
-    stderr.write("Warning: `configlet generate` exited with an error, 'README.md' is likely malformed.\n");
+    stderr.write('Warning: `configlet generate` exited with an error, \'README.md\' is likely malformed.\n');
   }
 
   // The output from file generation is not always well-formatted, use dartfmt to clean it up
   final fmtSuccess =
-      await runProcess("pub", ["run", "dart_style:format", "-i", "0", "-l", "120", "-w", exerciseDir.path]);
+      await runProcess('pub', ['run', 'dart_style:format', '-i', '0', '-l', '120', '-w', exerciseDir.path]);
   if (fmtSuccess) {
-    stdout.write("Successfully created a rough-draft of tests at '$testFileName'.\n");
-    stdout.write("You should check this over and fix or refine as necessary.\n");
+    stdout.write('Successfully created a rough-draft of tests at \'$testFileName\'.\n');
+    stdout.write('You should check this over and fix or refine as necessary.\n');
   } else {
     stderr
-        .write("Warning: dart_style:format exited with an error, files in \'${exerciseDir.path}\' may be malformed.\n");
+        .write('Warning: dart_style:format exited with an error, files in \'${exerciseDir.path}\' may be malformed.\n');
   }
 
   // Install deps
   Directory.current = exerciseDir;
 
-  final pubSuccess = await runProcess("pub", ["get"]);
+  final pubSuccess = await runProcess('pub', ['get']);
   assert(pubSuccess);
 }
 
-String _protectWhitespaces(String input) => input..replaceAll("\\", '\\\\');
+String _protectWhitespaces(String input) => input..replaceAll('\\', '\\\\');
 
 bool _containsWhitespaceCodes(String input) {
   return input.contains('\n') || input.contains('\r') || input.contains('\t');
@@ -339,10 +339,10 @@ String repr(Object x, {String typeDeclaration}) {
     String result = x
         .replaceAll('\'', r"\'")
         .replaceAll('\n', r'\n')
-        .replaceAll("\r", r"\r")
-        .replaceAll("\t", r"\t")
+        .replaceAll('\r', r'\r')
+        .replaceAll('\t', r'\t')
         .replaceAll(r'$', r'\$');
-    return "'$result'";
+    return '\'$result\'';
   }
 
   if (x is Iterable) {
@@ -356,9 +356,9 @@ String repr(Object x, {String typeDeclaration}) {
     }
 
     if (x is List) {
-      return '$iterableType[${x.map(repr).join(", ")}]';
+      return '$iterableType[${x.map(repr).join(', ')}]';
     } else if (x is Set) {
-      return '$iterableType{${x.map(repr).join(", ")}}';
+      return '$iterableType{${x.map(repr).join(', ')}}';
     }
   }
 
@@ -366,16 +366,16 @@ String repr(Object x, {String typeDeclaration}) {
     return _defineMap(x, '${getMapType(x)}');
   }
 
-  return "$x";
+  return '$x';
 }
 
 String _defineMap(Map x, String iterableType) {
   final pairs = <String>[];
   for (var k in x.keys) {
-    pairs.add("${repr(k)}: ${repr(x[k])}");
+    pairs.add('${repr(k)}: ${repr(x[k])}');
   }
 
-  return "$iterableType{${pairs.join(', ')}}";
+  return '$iterableType{${pairs.join(', ')}}';
 }
 
 /// A helper method to get the inside type of an iterable
@@ -386,7 +386,7 @@ String getIterableType(Iterable iter) {
     return types.first;
   }
 
-  return "Object";
+  return 'Object';
 }
 
 /// A helper method to get the inside type of a map
@@ -403,15 +403,15 @@ String getMapType(Map map) {
 /// Get a human-friendly type of a variable
 String getFriendlyType(Object x) {
   if (x is String) {
-    return "String";
+    return 'String';
   }
 
   if (x is Iterable) {
-    return "List<${getIterableType(x)}>";
+    return 'List<${getIterableType(x)}>';
   }
 
   if (x is Map) {
-    return "Map<${getIterableType(x.keys)}, ${getIterableType(x.values)}>";
+    return 'Map<${getIterableType(x.keys)}, ${getIterableType(x.values)}>';
   }
 
   if (x is num) {
@@ -452,15 +452,15 @@ Future main(List<String> args) async {
   }
 
   final exerciseName = restArgs.first;
-  final exerciseDir = new Directory("exercises/${kebabCase(exerciseName)}");
+  final exerciseDir = new Directory('exercises/${kebabCase(exerciseName)}');
 
   // Create dir
   final currentDir = Directory.current;
   final exerciseFilename = snakeCase(exerciseName);
 
   // Get test cases from canonical-data.json, format tests
-  if (arguments["spec-path"] != null) {
-    String canonicalFilePath = "${arguments['spec-path']}/exercises/$exerciseName/canonical-data.json";
+  if (arguments['spec-path'] != null) {
+    String canonicalFilePath = '${arguments['spec-path']}/exercises/$exerciseName/canonical-data.json';
     try {
       final File canonicalDataJson = new File(canonicalFilePath);
       final source = await canonicalDataJson.readAsString();
@@ -471,14 +471,14 @@ Future main(List<String> args) async {
         _generateExercise(specification, exerciseFilename, exerciseName, exerciseDir, version, arguments);
       }
     } on FileSystemException {
-      stderr.write("Could not open file '$canonicalFilePath', exiting.\n");
+      stderr.write('Could not open file \'$canonicalFilePath\', exiting.\n');
       exit(1);
     } on FormatException {
-      stderr.write("File '$canonicalFilePath' is not valid JSON, exiting.\n");
+      stderr.write('File \'$canonicalFilePath\' is not valid JSON, exiting.\n');
       exit(1);
     }
   } else {
-    print("Could not find: ${arguments['spec-path']}/exercises/$exerciseName/canonical-data.json");
+    print('Could not find: ${arguments['spec-path']}/exercises/$exerciseName/canonical-data.json');
   }
 
   Directory.current = currentDir;

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -293,12 +293,13 @@ Future main(List<String> args) async {
   }
 
   // The output from file generation is not always well-formatted, use dartfmt to clean it up
-  final fmtSuccess = await runProcess("dartfmt", ["-l", "120", "-w", exerciseDir.path]);
+  final fmtSuccess =
+      await runProcess("pub", ["run", "dart_style:format", "-i", "0", "-l", "120", "-w", exerciseDir.path]);
   if (fmtSuccess) {
     stdout.write("Successfully created a rough-draft of tests at '$testFileName'.\n");
     stdout.write("You should check this over and fix or refine as necessary.\n");
   } else {
-    stderr.write("Warning: dartfmt exited with an error, files in '${exerciseDir.path}' may be malformed.\n");
+    stderr.write("Warning: dart_style:format exited with an error, files in '${exerciseDir.path}' may be malformed.\n");
   }
 
   // Install deps

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -264,10 +264,10 @@ void _generateExercise(Map<String, Object> specification, String exerciseFilenam
 }
 
 /// If a string contains a single backslash, we need to add another behind it, so the backslash remains.
-String _escapeBackslash(List<String> input) {
+String _escapeBackslash(String input) {
   List<String> result = <String>[];
 
-  input.forEach((String value) {
+  input.split('').forEach((String value) {
     if (value == r'\') {
       result.add(value + value);
     } else {
@@ -381,7 +381,7 @@ String _handleQuotes(String input) {
 /// `typeDeclaration` is the determined return type and used to determine the type within collections.
 String _repr(Object x, {String typeDeclaration}) {
   if (x is String) {
-    String result = _escapeBackslash(x.split(''));
+    String result = _escapeBackslash(x);
     result = result
         .replaceAll('\'', r"\'")
         .replaceAll('\n', r'\n')

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -6,10 +6,10 @@ import 'package:args/args.dart';
 import 'package:path/path.dart' show dirname;
 
 // Constants
-const String scriptFilename = 'create-exercise';
+const String scriptFileName = 'create-exercise';
 
 final parser = new ArgParser()
-  ..addSeparator('Usage: $scriptFilename [--spec-path path] <slug>')
+  ..addSeparator('Usage: $scriptFileName [--spec-path path] <slug>')
   ..addOption('spec-path', help: 'The location of the problem-specifications directory.', valueHelp: 'path');
 
 // Helpers

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -5,10 +5,10 @@ import 'package:args/args.dart';
 import 'package:path/path.dart' show dirname;
 
 // Constants
-const scriptFileName = 'create-exercise';
+const _scriptFileName = 'create-exercise';
 
-final parser = ArgParser()
-  ..addSeparator('Usage: $scriptFileName [--spec-path path] <slug>')
+final _parser = ArgParser()
+  ..addSeparator('Usage: $_scriptFileName [--spec-path path] <slug>')
   ..addOption('spec-path', help: 'The location of the problem-specifications directory.', valueHelp: 'path');
 
 // Helpers
@@ -139,14 +139,14 @@ String testCaseTemplate(String exerciseName, Map<String, Object> testCase, {bool
     ''';
   }
 
-  String description = repr(testCase['description']);
+  String description = _repr(testCase['description']);
   String object = camelCase(exerciseName);
   String method = testCase['property'].toString();
-  String expected = repr(testCase['expected'], typeDeclaration: returnType);
+  String expected = _repr(testCase['expected'], typeDeclaration: returnType);
 
   returnType = _finalizeReturnType(expected, returnType);
   Map<String, dynamic> input = testCase['input'] as Map<String, dynamic>;
-  String arguments = input.keys.map((k) => repr(input[k])).join(', ');
+  String arguments = input.keys.map((k) => _repr(input[k])).join(', ');
   arguments = arguments == 'null' ? '' : arguments;
 
   if (_containsWhitespaceCodes(arguments)) {
@@ -227,7 +227,7 @@ void _generateExercise(Map<String, Object> specification, String exerciseFilenam
   // Generate README
   final dartRoot = '${dirname(Platform.script.toFilePath())}/..';
   final configletLoc = '$dartRoot/bin/configlet';
-  final genSuccess = runProcess(
+  final genSuccess = _runProcess(
       configletLoc, ['generate', '$dartRoot', '--spec-path', '${arguments['spec-path']}', '--only', exerciseName]);
   if (genSuccess) {
     stdout.write('Successfully created README.md\n');
@@ -236,7 +236,7 @@ void _generateExercise(Map<String, Object> specification, String exerciseFilenam
   }
 
   // The output from file generation is not always well-formatted, use dartfmt to clean it up
-  final fmtSuccess = runProcess('pub', ['run', 'dart_style:format', '-i', '0', '-l', '120', '-w', exerciseDir.path]);
+  final fmtSuccess = _runProcess('pub', ['run', 'dart_style:format', '-i', '0', '-l', '120', '-w', exerciseDir.path]);
   if (fmtSuccess) {
     stdout.write('Successfully created a rough-draft of tests at \'$testFileName\'.\n');
     stdout.write('You should check this over and fix or refine as necessary.\n');
@@ -248,7 +248,7 @@ void _generateExercise(Map<String, Object> specification, String exerciseFilenam
   // Install deps
   Directory.current = exerciseDir;
 
-  final pubSuccess = runProcess('pub', ['get']);
+  final pubSuccess = _runProcess('pub', ['get']);
   assert(pubSuccess);
 }
 
@@ -279,7 +279,7 @@ String _determineBestReturnType(List<dynamic> specCases) {
   final dynamic first = expectedList.isNotEmpty ? expectedList.first : null;
 
   if (first is Iterable) {
-    final iterableType = '${getIterableType(first)}';
+    final iterableType = '${_getIterableType(first)}';
 
     if (first is List) {
       return 'List<$iterableType>';
@@ -291,7 +291,7 @@ String _determineBestReturnType(List<dynamic> specCases) {
   }
 
   if (first is Map) {
-    return 'Map${getMapType(first)}';
+    return 'Map${_getMapType(first)}';
   }
 
   if (first is String) {
@@ -366,7 +366,7 @@ String _handleQuotes(String arguments) {
 /// `repr` takes in any object and tries to coerce it to a String in such a way that it is suitable to include in code.
 /// Based on the python `repr` function, but only works for basic types: String, Iterable, Map, and primitive types
 /// `typeDeclaration` is the determined return type and used to determine the type within collections.
-String repr(Object x, {String typeDeclaration}) {
+String _repr(Object x, {String typeDeclaration}) {
   if (x is String) {
     String result = _ensureBackslashesTreatedAsBackslashes(x.split(''));
     result = result
@@ -384,21 +384,21 @@ String repr(Object x, {String typeDeclaration}) {
     if (typeDeclaration != null) {
       final iterables = RegExp(r'List|Map|Set');
       final knownType = '<${typeDeclaration.replaceFirst(iterables, '')}>';
-      final currentType = '<${getIterableType(x)}>';
+      final currentType = '<${_getIterableType(x)}>';
       iterableType = knownType == currentType ? knownType : currentType;
     } else {
-      iterableType = '<${getIterableType(x)}>';
+      iterableType = '<${_getIterableType(x)}>';
     }
 
     if (x is List) {
-      return '$iterableType[${x.map(repr).join(', ')}]';
+      return '$iterableType[${x.map(_repr).join(', ')}]';
     } else if (x is Set) {
-      return '$iterableType{${x.map(repr).join(', ')}}';
+      return '$iterableType{${x.map(_repr).join(', ')}}';
     }
   }
 
   if (x is Map) {
-    return _defineMap(x, '${getMapType(x)}');
+    return _defineMap(x, '${_getMapType(x)}');
   }
 
   return '$x';
@@ -407,15 +407,15 @@ String repr(Object x, {String typeDeclaration}) {
 String _defineMap(Map x, String iterableType) {
   final pairs = <String>[];
   for (var k in x.keys) {
-    pairs.add('${repr(k)}: ${repr(x[k])}');
+    pairs.add('${_repr(k)}: ${_repr(x[k])}');
   }
 
   return '$iterableType{${pairs.join(', ')}}';
 }
 
 /// A helper method to get the inside type of an iterable
-String getIterableType(Iterable iter) {
-  Set<String> types = iter.map(getFriendlyType).toSet();
+String _getIterableType(Iterable iter) {
+  Set<String> types = iter.map(_getFriendlyType).toSet();
 
   if (types.length == 1) {
     return types.first;
@@ -425,9 +425,9 @@ String getIterableType(Iterable iter) {
 }
 
 /// A helper method to get the inside type of a map
-String getMapType(Map map) {
-  Set<String> keyTypes = map.keys.map(getFriendlyType).toSet();
-  Set<String> valueTypes = map.values.map(getFriendlyType).toSet();
+String _getMapType(Map map) {
+  Set<String> keyTypes = map.keys.map(_getFriendlyType).toSet();
+  Set<String> valueTypes = map.values.map(_getFriendlyType).toSet();
 
   String mapKeyType = keyTypes.length == 1 ? keyTypes.first : 'dynamic';
   String mapValueType = valueTypes.length == 1 ? valueTypes.first : 'dynamic';
@@ -436,17 +436,17 @@ String getMapType(Map map) {
 }
 
 /// Get a human-friendly type of a variable
-String getFriendlyType(Object x) {
+String _getFriendlyType(Object x) {
   if (x is String) {
     return 'String';
   }
 
   if (x is Iterable) {
-    return 'List<${getIterableType(x)}>';
+    return 'List<${_getIterableType(x)}>';
   }
 
   if (x is Map) {
-    return 'Map<${getIterableType(x.keys)}, ${getIterableType(x.values)}>';
+    return 'Map<${_getIterableType(x.keys)}, ${_getIterableType(x.values)}>';
   }
 
   if (x is num) {
@@ -464,7 +464,7 @@ String getFriendlyType(Object x) {
 
 // runProcess runs a process, writes any stdout/stderr output.
 // Returns true if the cmd was successful, false otherwise
-bool runProcess(String cmd, List<String> arguments) {
+bool _runProcess(String cmd, List<String> arguments) {
   final res = Process.runSync(cmd, arguments, runInShell: true);
   if (!res.stdout.toString().isEmpty) {
     stdout.write(res.stdout);
@@ -478,11 +478,11 @@ bool runProcess(String cmd, List<String> arguments) {
 }
 
 void main(List<String> args) {
-  final arguments = parser.parse(args);
+  final arguments = _parser.parse(args);
   final restArgs = arguments.rest;
 
   if (restArgs.isEmpty) {
-    stderr.write(parser.usage);
+    stderr.write(_parser.usage);
     exit(1);
   }
 

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -65,9 +65,15 @@ String testCasesString = """
       // TODO
     });""";
 
-String testTemplate(String name) => """
-import 'package:test/test.dart';
-import 'package:${snakeCase(name)}/${snakeCase(name)}.dart';
+/// The test template sorts the import of packages, instantiates an instance of the exercise class, and defines the main
+/// function's group of tests.
+String testTemplate(String name) {
+  final packages = <String>[name, "test"];
+  packages.sort();
+
+  return """
+import 'package:${snakeCase(packages[0])}/${snakeCase(packages[0])}.dart';
+import 'package:${snakeCase(packages[1])}/${snakeCase(packages[1])}.dart';
 
 final ${camelCase(name)} = new ${pascalCase(name)}();
 
@@ -77,6 +83,7 @@ $testCasesString
   });
 }
 """;
+}
 
 String pubTemplate(String name) => """
 name: '${snakeCase(name)}'

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -142,12 +142,24 @@ String testCaseTemplate(String name, Map<String, Object> testCase, {bool firstTe
   Map<String, dynamic> input = testCase['input'] as Map<String, dynamic>;
   String arguments = input.keys.map((k) => repr(input[k])).join(', ');
 
-  return """
+  if (_containsWhitespaceCodes(arguments)) {
+    arguments = _protectWhitespaces(arguments);
+  }
+
+  final result = '''
     test($description, () {
       final $resultType result = $object.$method($arguments);
       expect(result, equals($expected));
     }, skip: ${!skipTests});
-  """;
+''';
+
+  return result;
+}
+
+String _protectWhitespaces(String input) => input..replaceAll("\\", '\\\\');
+
+bool _containsWhitespaceCodes(String input) {
+  return input.contains('\n') || input.contains('\r') || input.contains('\t');
 }
 
 /// `repr` takes in any object and tries to coerce it to a String in such a way that it is suitable to include in code.

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -221,9 +221,11 @@ Set<dynamic> retrieveListOfExpected(List<dynamic> list, {Set<dynamic> expectedTy
 
       if (entry.containsKey('expected')) {
         if (entry['expected'] is Map) {
-          if ((entry['expected'] as Map).containsKey('error')) {
-            addEntry = !addEntry;
-          }
+          addEntry = !(entry['expected'] as Map).containsKey('error');
+        }
+
+        if (entry['expected'] is Iterable) {
+          addEntry = (entry['expected'] as Iterable).isNotEmpty;
         }
 
         if (addEntry) {

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -161,7 +161,7 @@ String testCaseTemplate(String exerciseName, Map<String, Object> testCase, {bool
   arguments = arguments == 'null' ? '' : arguments;
 
   if (_containsWhitespaceCodes(arguments)) {
-    arguments = _protectWhitespaces(arguments);
+    arguments = _escapeWhitespace(arguments);
   }
 
   final result = '''
@@ -264,7 +264,7 @@ void _generateExercise(Map<String, Object> specification, String exerciseFilenam
 }
 
 /// If a string contains a single backslash, we need to add another behind it, so the backslash remains.
-String _ensureBackslashesTreatedAsBackslashes(List<String> input) {
+String _escapeBackslash(List<String> input) {
   List<String> result = <String>[];
 
   input.forEach((String value) {
@@ -278,7 +278,7 @@ String _ensureBackslashesTreatedAsBackslashes(List<String> input) {
   return result.join();
 }
 
-String _protectWhitespaces(String input) => input..replaceAll('\\', '\\\\');
+String _escapeWhitespace(String input) => input..replaceAll('\\', '\\\\');
 
 bool _containsWhitespaceCodes(String input) {
   return input.contains('\n') || input.contains('\r') || input.contains('\t');
@@ -381,7 +381,7 @@ String _handleQuotes(String input) {
 /// `typeDeclaration` is the determined return type and used to determine the type within collections.
 String _repr(Object x, {String typeDeclaration}) {
   if (x is String) {
-    String result = _ensureBackslashesTreatedAsBackslashes(x.split(''));
+    String result = _escapeBackslash(x.split(''));
     result = result
         .replaceAll('\'', r"\'")
         .replaceAll('\n', r'\n')

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -69,9 +69,9 @@ String testTemplate(String name) => """
 import 'package:test/test.dart';
 import 'package:${snakeCase(name)}/${snakeCase(name)}.dart';
 
-void main() {
-  final ${camelCase(name)} = new ${pascalCase(name)}();
+final ${camelCase(name)} = new ${pascalCase(name)}();
 
+void main() {
   group('${pascalCase(name)}', () {
 $testCasesString
   });

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -384,10 +384,15 @@ Future main(List<String> args) async {
   }
 
   final exerciseName = restArgs.first;
+  final exerciseDir = new Directory("exercises/${kebabCase(exerciseName)}");
+
+  if (await exerciseDir.exists()) {
+    stderr.write("$exerciseName already exist\n");
+    exit(1);
+  }
 
   // Create dir
   final currentDir = Directory.current;
-  final exerciseDir = new Directory("exercises/${kebabCase(exerciseName)}");
   final filename = snakeCase(exerciseName);
   String version;
 
@@ -411,11 +416,6 @@ Future main(List<String> args) async {
     }
   } else {
     print("Could not find: ${arguments['spec-path']}/exercises/$exerciseName/canonical-data.json");
-  }
-
-  if (await exerciseDir.exists()) {
-    stderr.write("$exerciseName already exist\n");
-    exit(1);
   }
 
   await new Directory("${exerciseDir.path}/.meta").create(recursive: true);

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -6,25 +6,25 @@ import 'package:args/args.dart';
 import 'package:path/path.dart' show dirname;
 
 // Constants
-const String scriptFileName = 'create-exercise';
+const scriptFileName = 'create-exercise';
 
-final parser = new ArgParser()
+final parser = ArgParser()
   ..addSeparator('Usage: $scriptFileName [--spec-path path] <slug>')
   ..addOption('spec-path', help: 'The location of the problem-specifications directory.', valueHelp: 'path');
 
 // Helpers
-List<String> words(final String str) {
+List<String> words(String str) {
   if (str == null) return [''];
 
   return str
       .toLowerCase()
-      .replaceAll(new RegExp(r'[^a-z0-9]'), ' ')
-      .replaceAll(new RegExp(r' +'), ' ')
+      .replaceAll(RegExp(r'[^a-z0-9]'), ' ')
+      .replaceAll(RegExp(r' +'), ' ')
       .trim()
       .split(' ');
 }
 
-String upperFirst(final String str) {
+String upperFirst(String str) {
   if (str == null || str.length == 0) return '';
 
   final chars = str.split('');
@@ -75,7 +75,7 @@ String testTemplate(String name) {
 import 'package:${snakeCase(packages[0])}/${snakeCase(packages[0])}.dart';
 import 'package:${snakeCase(packages[1])}/${snakeCase(packages[1])}.dart';
 
-final ${camelCase(name)} = new ${pascalCase(name)}();
+final ${camelCase(name)} = ${pascalCase(name)}();
 
 void main() {
   group('${pascalCase(name)}', () {
@@ -219,16 +219,16 @@ void _generateExercise(Map<String, Object> specification, String exerciseFilenam
   _testCasesString = testCaseTemplate(exerciseName, specification);
   print('Found: ${arguments['spec-path']}/exercises/$exerciseName/canonical-data.json');
 
-  await new Directory('${exerciseDir.path}/lib').create(recursive: true);
-  await new Directory('${exerciseDir.path}/test').create(recursive: true);
+  await Directory('${exerciseDir.path}/lib').create(recursive: true);
+  await Directory('${exerciseDir.path}/test').create(recursive: true);
 
   // Create files
   String testFileName = '${exerciseDir.path}/test/${exerciseFilename}_test.dart';
-  await new File('${exerciseDir.path}/lib/example.dart').writeAsString(exampleTemplate(exerciseName));
-  await new File('${exerciseDir.path}/lib/${exerciseFilename}.dart').writeAsString(mainTemplate(exerciseName));
-  await new File(testFileName).writeAsString(testTemplate(exerciseName));
-  await new File('${exerciseDir.path}/analysis_options.yaml').writeAsString(analysisOptionsTemplate());
-  await new File('${exerciseDir.path}/pubspec.yaml').writeAsString(pubTemplate(exerciseName, version));
+  await File('${exerciseDir.path}/lib/example.dart').writeAsString(exampleTemplate(exerciseName));
+  await File('${exerciseDir.path}/lib/${exerciseFilename}.dart').writeAsString(mainTemplate(exerciseName));
+  await File(testFileName).writeAsString(testTemplate(exerciseName));
+  await File('${exerciseDir.path}/analysis_options.yaml').writeAsString(analysisOptionsTemplate());
+  await File('${exerciseDir.path}/pubspec.yaml').writeAsString(pubTemplate(exerciseName, version));
 
   // Generate README
   final dartRoot = '${dirname(Platform.script.toFilePath())}/..';
@@ -323,10 +323,10 @@ String _determineBestReturnType(List<dynamic> specCases) {
 
 Set<dynamic> retrieveListOfExpected(List<dynamic> list, {Set<dynamic> expectedTypeSet}) {
   if (expectedTypeSet == null) {
-    expectedTypeSet = new Set<dynamic>();
+    expectedTypeSet = Set<dynamic>();
   }
 
-  for (int count = 0; count < list.length; count++) {
+  for (var count = 0; count < list.length; count++) {
     if (list[count] is Map) {
       Map entry = list[count] as Map;
       bool addEntry = true;
@@ -389,7 +389,7 @@ String repr(Object x, {String typeDeclaration}) {
     String iterableType;
 
     if (typeDeclaration != null) {
-      final RegExp iterables = new RegExp(r'List|Map|Set');
+      final iterables = RegExp(r'List|Map|Set');
       final knownType = '<${typeDeclaration.replaceFirst(iterables, '')}>';
       final currentType = '<${getIterableType(x)}>';
       iterableType = knownType == currentType ? knownType : currentType;
@@ -494,7 +494,7 @@ Future main(List<String> args) async {
   }
 
   final exerciseName = restArgs.first;
-  final exerciseDir = new Directory('exercises/${kebabCase(exerciseName)}');
+  final exerciseDir = Directory('exercises/${kebabCase(exerciseName)}');
 
   // Create dir
   final currentDir = Directory.current;
@@ -504,9 +504,9 @@ Future main(List<String> args) async {
   if (arguments['spec-path'] != null) {
     String canonicalFilePath = '${arguments['spec-path']}/exercises/$exerciseName/canonical-data.json';
     try {
-      final File canonicalDataJson = new File(canonicalFilePath);
+      final canonicalDataJson = File(canonicalFilePath);
       final source = await canonicalDataJson.readAsString();
-      final Map<String, Object> specification = json.decode(source) as Map<String, Object>;
+      final specification = json.decode(source) as Map<String, Object>;
       final version = specification['version'].toString();
 
       if (await _doGenerate(exerciseDir, exerciseName, version)) {

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -235,6 +235,21 @@ void _generateExercise(Map<String, Object> specification, String exerciseFilenam
   assert(pubSuccess);
 }
 
+/// If a string contains a single backslash, we need to add another behind it, so the backslash remains.
+String _ensureBackslashesTreatedAsBackslashes(List<String> input) {
+  List<String> result = <String>[];
+
+  input.forEach((String value) {
+    if (value == r'\') {
+      result.add(value + value);
+    } else {
+      result.add(value);
+    }
+  });
+
+  return StringBuffer(result.join()).toString();
+}
+
 String _protectWhitespaces(String input) => input..replaceAll('\\', '\\\\');
 
 bool _containsWhitespaceCodes(String input) {
@@ -336,7 +351,8 @@ String _handleQuotes(String arguments) {
 /// `typeDeclaration` is the determined return type and used to determine the type within collections.
 String repr(Object x, {String typeDeclaration}) {
   if (x is String) {
-    String result = x
+    String result = _ensureBackslashesTreatedAsBackslashes(x.split(''));
+    result = result
         .replaceAll('\'', r"\'")
         .replaceAll('\n', r'\n')
         .replaceAll('\r', r'\r')

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -393,14 +393,14 @@ Future main(List<String> args) async {
 
   // Create dir
   final currentDir = Directory.current;
-  final filename = snakeCase(exerciseName);
+  final exerciseFilename = snakeCase(exerciseName);
   String version;
 
   // Get test cases from canonical-data.json, format tests
   if (arguments["spec-path"] != null) {
-    String filename = "${arguments['spec-path']}/exercises/$exerciseName/canonical-data.json";
+    String canonicalFilePath = "${arguments['spec-path']}/exercises/$exerciseName/canonical-data.json";
     try {
-      final File canonicalDataJson = new File(filename);
+      final File canonicalDataJson = new File(canonicalFilePath);
       final source = await canonicalDataJson.readAsString();
       final Map<String, Object> specification = json.decode(source) as Map<String, Object>;
 
@@ -408,10 +408,10 @@ Future main(List<String> args) async {
       _testCasesString = testCaseTemplate(exerciseName, specification);
       print("Found: ${arguments['spec-path']}/exercises/$exerciseName/canonical-data.json");
     } on FileSystemException {
-      stderr.write("Could not open file '$filename', exiting.\n");
+      stderr.write("Could not open file '$canonicalFilePath', exiting.\n");
       exit(1);
     } on FormatException {
-      stderr.write("File '$filename' is not valid JSON, exiting.\n");
+      stderr.write("File '$canonicalFilePath' is not valid JSON, exiting.\n");
       exit(1);
     }
   } else {
@@ -423,10 +423,10 @@ Future main(List<String> args) async {
   await new Directory("${exerciseDir.path}/test").create(recursive: true);
 
   // Create files
-  String testFileName = "${exerciseDir.path}/test/${filename}_test.dart";
+  String testFileName = "${exerciseDir.path}/test/${exerciseFilename}_test.dart";
   await new File('${exerciseDir.path}/.meta/version').writeAsString(version);
   await new File("${exerciseDir.path}/lib/example.dart").writeAsString(exampleTemplate(exerciseName));
-  await new File("${exerciseDir.path}/lib/${filename}.dart").writeAsString(mainTemplate(exerciseName));
+  await new File("${exerciseDir.path}/lib/${exerciseFilename}.dart").writeAsString(mainTemplate(exerciseName));
   await new File(testFileName).writeAsString(testTemplate(exerciseName));
   await new File("${exerciseDir.path}/analysis_options.yaml").writeAsString(analysisOptionsTemplate());
   await new File("${exerciseDir.path}/pubspec.yaml").writeAsString(pubTemplate(exerciseName));

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -123,7 +123,7 @@ String testCaseTemplate(String exerciseName, Map<String, Object> testCase, {bool
     }
 
     // We have a group, not a case
-    String description = testCase['description'] as String;
+    String description = _handleQuotes(testCase['description'] as String);
 
     // Build the tests up recursively, only first test should be skipped
     List<String> testList = <String>[];
@@ -242,6 +242,18 @@ Set<dynamic> retrieveListOfExpected(List<dynamic> list, {Set<dynamic> expectedTy
   }
 
   return expectedTypeSet;
+}
+
+String _handleQuotes(String arguments) {
+  if (arguments != null) {
+    final firstChar = arguments[0];
+    final lastChar = arguments[arguments.length - 1];
+    final shortenArgs = arguments.substring(1, arguments.length - 1).replaceAll('\'', '\\\'');
+
+    return '$firstChar$shortenArgs$lastChar';
+  } else {
+    return null;
+  }
 }
 
 /// `repr` takes in any object and tries to coerce it to a String in such a way that it is suitable to include in code.

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -173,8 +173,8 @@ bool _containsWhitespaceCodes(String input) {
 /// Based on the python `repr` function, but only works for basic types: String, Iterable, Map, and primitive types
 String repr(Object x) {
   if (x is String) {
-    String result = x.replaceAll('"', r'\"').replaceAll("\n", r"\n").replaceAll(r"$", r"\$");
-    return '"$result"';
+    String result = x.replaceAll('\'', r"\'").replaceAll('\n', r'\n').replaceAll(r'$', r'\$');
+    return "'$result'";
   }
 
   if (x is Iterable) {

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -250,7 +250,13 @@ bool _isEmptyCollection(dynamic item) {
 /// `typeDeclaration` is the determined return type and used to determine the type within collections.
 String repr(Object x, {String typeDeclaration}) {
   if (x is String) {
-    String result = x.replaceAll('\'', r"\'").replaceAll('\n', r'\n').replaceAll(r'$', r'\$');
+    String result = x
+        .replaceAll('\'', r"\'")
+        .replaceAll('\n', r'\n')
+        .replaceAll("\r", r"\r")
+        .replaceAll("\s", r"\s")
+        .replaceAll("\t", r"\t")
+        .replaceAll(r'$', r'\$');
     return "'$result'";
   }
 

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -38,13 +38,13 @@ String camelCase(String str, {bool isUpperFirst = false}) {
   return (isUpperFirst ? upperFirst(first) : first) + rest.map(upperFirst).join('');
 }
 
-/// Converts given string to pascalCase.
+/// Converts given string to PascalCase.
 String pascalCase(String str) => camelCase(str, isUpperFirst: true);
 
-/// Converts given string to snakeCase.
+/// Converts given string to snake_case.
 String snakeCase(String str) => words(str).join('_');
 
-/// Converts given string to kebabCase.
+/// Converts given string to kebab-case.
 String kebabCase(String str) => words(str).join('-');
 
 // Templates

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -404,7 +404,7 @@ Future main(List<String> args) async {
       final source = await canonicalDataJson.readAsString();
       final Map<String, Object> specification = json.decode(source) as Map<String, Object>;
 
-      version = specification['version'] as String;
+      version = specification['version'].toString();
       _testCasesString = testCaseTemplate(exerciseName, specification);
       print("Found: ${arguments['spec-path']}/exercises/$exerciseName/canonical-data.json");
     } on FileSystemException {
@@ -424,7 +424,7 @@ Future main(List<String> args) async {
 
   // Create files
   String testFileName = "${exerciseDir.path}/test/${filename}_test.dart";
-  await new File("${exerciseDir.path}/.meta/version").writeAsString(version);
+  await new File('${exerciseDir.path}/.meta/version').writeAsString(version);
   await new File("${exerciseDir.path}/lib/example.dart").writeAsString(exampleTemplate(exerciseName));
   await new File("${exerciseDir.path}/lib/${filename}.dart").writeAsString(mainTemplate(exerciseName));
   await new File(testFileName).writeAsString(testTemplate(exerciseName));

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -85,8 +85,9 @@ $_testCasesString
 ''';
 }
 
-String pubTemplate(String name) => '''
+String pubTemplate(String name, String version) => '''
 name: '${snakeCase(name)}'
+version: $version
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:
@@ -218,18 +219,16 @@ void _generateExercise(Map<String, Object> specification, String exerciseFilenam
   _testCasesString = testCaseTemplate(exerciseName, specification);
   print('Found: ${arguments['spec-path']}/exercises/$exerciseName/canonical-data.json');
 
-  await new Directory('${exerciseDir.path}/.meta').create(recursive: true);
   await new Directory('${exerciseDir.path}/lib').create(recursive: true);
   await new Directory('${exerciseDir.path}/test').create(recursive: true);
 
   // Create files
   String testFileName = '${exerciseDir.path}/test/${exerciseFilename}_test.dart';
-  await new File('${exerciseDir.path}/.meta/version').writeAsString(version);
   await new File('${exerciseDir.path}/lib/example.dart').writeAsString(exampleTemplate(exerciseName));
   await new File('${exerciseDir.path}/lib/${exerciseFilename}.dart').writeAsString(mainTemplate(exerciseName));
   await new File(testFileName).writeAsString(testTemplate(exerciseName));
   await new File('${exerciseDir.path}/analysis_options.yaml').writeAsString(analysisOptionsTemplate());
-  await new File('${exerciseDir.path}/pubspec.yaml').writeAsString(pubTemplate(exerciseName));
+  await new File('${exerciseDir.path}/pubspec.yaml').writeAsString(pubTemplate(exerciseName, version));
 
   // Generate README
   final dartRoot = '${dirname(Platform.script.toFilePath())}/..';

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -151,6 +151,7 @@ String testCaseTemplate(String exerciseName, Map<String, Object> testCase, {bool
 
   Map<String, dynamic> input = testCase['input'] as Map<String, dynamic>;
   String arguments = input.keys.map((k) => repr(input[k])).join(', ');
+  arguments = arguments == 'null' ? '' : arguments;
 
   if (_containsWhitespaceCodes(arguments)) {
     arguments = _protectWhitespaces(arguments);

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -200,7 +200,13 @@ String getFriendlyType(Object x) {
   }
 
   if (x is num) {
-    return "num";
+    if (x is int) {
+      return 'int';
+    } else if (x is double) {
+      return 'double';
+    } else {
+      return 'num';
+    }
   }
 
   return x.runtimeType.toString();

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -264,7 +264,7 @@ String _ensureBackslashesTreatedAsBackslashes(List<String> input) {
     }
   });
 
-  return StringBuffer(result.join()).toString();
+  return result.join();
 }
 
 String _protectWhitespaces(String input) => input..replaceAll('\\', '\\\\');

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -207,6 +207,10 @@ String _determineBestReturnType(List<dynamic> specCases) {
       return 'num';
     }
   }
+
+  if (first is bool) {
+    return 'bool';
+  }
   return '';
 }
 

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -15,12 +15,7 @@ final parser = ArgParser()
 List<String> words(String str) {
   if (str == null) return [''];
 
-  return str
-      .toLowerCase()
-      .replaceAll(RegExp(r'[^a-z0-9]'), ' ')
-      .replaceAll(RegExp(r' +'), ' ')
-      .trim()
-      .split(' ');
+  return str.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]'), ' ').replaceAll(RegExp(r' +'), ' ').trim().split(' ');
 }
 
 String upperFirst(String str) {
@@ -241,8 +236,7 @@ void _generateExercise(Map<String, Object> specification, String exerciseFilenam
   }
 
   // The output from file generation is not always well-formatted, use dartfmt to clean it up
-  final fmtSuccess =
-      runProcess('pub', ['run', 'dart_style:format', '-i', '0', '-l', '120', '-w', exerciseDir.path]);
+  final fmtSuccess = runProcess('pub', ['run', 'dart_style:format', '-i', '0', '-l', '120', '-w', exerciseDir.path]);
   if (fmtSuccess) {
     stdout.write('Successfully created a rough-draft of tests at \'$testFileName\'.\n');
     stdout.write('You should check this over and fix or refine as necessary.\n');

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -5,14 +5,14 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:path/path.dart' show dirname;
 
-/// Constants
+// Constants
 const String scriptFilename = 'create-exercise';
 
 final parser = new ArgParser()
   ..addSeparator('Usage: $scriptFilename [--spec-path path] <slug>')
   ..addOption('spec-path', help: 'The location of the problem-specifications directory.', valueHelp: 'path');
 
-/// Helpers
+// Helpers
 List<String> words(final String str) {
   if (str == null) return [''];
 
@@ -47,7 +47,7 @@ String snakeCase(String str) => words(str).join('_');
 
 String kebabCase(String str) => words(str).join('-');
 
-/// Templates
+// Templates
 String exampleTemplate(String name) => '''
 class ${pascalCase(name)} {
 

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -168,11 +168,11 @@ String _finalizeReturnType(String expected, String returnType) {
   final expectedMap = RegExp(r"(<[A-Za-z, ]+>\{[[a-zA-Z0-9':, ]{0,}\})");
 
   if (expected.contains(expectedIterable)) {
-    final iterableType = RegExp(r"(<[A-Za-z]+>)");
+    final iterableType = RegExp(r'(<[A-Za-z]+>)');
     final extracted = iterableType.stringMatch(expected);
     return returnType.contains('List<List') ? returnType : 'List$extracted';
   } else if (expected.contains(expectedMap)) {
-    final iterableType = RegExp(r"(<[A-Za-z, ]+>)");
+    final iterableType = RegExp(r'(<[A-Za-z, ]+>)');
     final extracted = iterableType.stringMatch(expected);
     return 'Map$extracted';
   } else {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,9 +7,9 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.38.4"
+    version: "0.38.5"
   args:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: args
       url: "https://pub.dartlang.org"
@@ -50,6 +50,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
+  coverage:
+    dependency: transitive
+    description:
+      name: coverage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.3"
   crypto:
     dependency: transitive
     description:
@@ -77,7 +84,7 @@ packages:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.26"
+    version: "0.1.27"
   glob:
     dependency: transitive
     description:
@@ -114,7 +121,7 @@ packages:
     source: hosted
     version: "3.1.3"
   io:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: io
       url: "https://pub.dartlang.org"
@@ -133,7 +140,14 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.26"
+    version: "0.3.27"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.11.3+2"
   matcher:
     dependency: transitive
     description:
@@ -294,7 +308,7 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   test_api:
     dependency: transitive
     description:
@@ -308,7 +322,7 @@ packages:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.10"
+    version: "0.2.12"
   typed_data:
     dependency: transitive
     description:
@@ -322,7 +336,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "1.2.0"
   watcher:
     dependency: transitive
     description:
@@ -336,9 +350,9 @@ packages:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.15"
+    version: "1.1.0"
   yaml:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: yaml
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,5 +8,8 @@ authors:
   - devkabiir
   - jvarness <jake.varness@gmail.com>
 dev_dependencies:
+  args: '^1.0.0'
   dart_style: '^1.0.8'
+  io: '^0.3.0'
   test: '>=0.12.24+8 <2.0.0'
+  yaml: '^2.0.0'

--- a/test/create_exercise_test.dart
+++ b/test/create_exercise_test.dart
@@ -165,8 +165,9 @@ void main() {
       });
 
       test('pubTemplate', () {
-        expect(pubTemplate('foo bar'), equals('''
+        expect(pubTemplate('foo bar', '1.0.0'), equals('''
 name: 'foo_bar'
+version: 1.0.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/test/create_exercise_test.dart
+++ b/test/create_exercise_test.dart
@@ -1,4 +1,5 @@
 import 'package:test/test.dart';
+
 import '../bin/create_exercise.dart';
 
 void main() {
@@ -125,6 +126,92 @@ void main() {
 
         test('symbols are replaced by a dash', () {
           expect(kebabCase('foo_bar'), equals('foo-bar'));
+        });
+      });
+    });
+
+    group('templates', () {
+      test('exampleTemplate', () {
+        expect(exampleTemplate('foo bar'), equals('''
+class FooBar {
+
+}
+'''));
+      });
+
+      test('mainTemplate', () {
+        expect(mainTemplate('foo bar'), equals('''
+class FooBar {
+  // Put your code here
+}
+'''));
+      });
+
+      test('testTemplate', () {
+        expect(testTemplate('foo bar'), equals('''
+import 'package:foo_bar/foo_bar.dart';
+import 'package:test/test.dart';
+
+final fooBar = new FooBar();
+
+void main() {
+  group('FooBar', () {
+    test('should work', () {
+      // TODO
+    });
+  });
+}
+'''));
+      });
+
+      test('pubTemplate', () {
+        expect(pubTemplate('foo bar'), equals('''
+name: 'foo_bar'
+environment:
+  sdk: '>=2.0.0 <3.0.0'
+dev_dependencies:
+  test: '<2.0.0'
+'''));
+      });
+
+      test('analysisOptionsTemplate', () {
+        expect(analysisOptionsTemplate(), equals('''
+analyzer:
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false
+  errors:
+    unused_element:        error
+    unused_import:         error
+    unused_local_variable: error
+    dead_code:             error
+
+linter:
+  rules:
+    # Error Rules
+    - avoid_relative_lib_imports
+    - avoid_types_as_parameter_names
+    - literal_only_boolean_expressions
+    - no_adjacent_strings_in_list
+    - valid_regexps
+'''));
+      });
+
+      group('testCaseTemplate tests', () {
+        test('simple test for a single case', () {
+          Map<String, dynamic> testCase = <String, dynamic>{
+            "description": "Zero is an Armstrong number",
+            "property": "isArmstrongNumber",
+            "input": {"number": 0},
+            "expected": true
+          };
+
+          expect(testCaseTemplate('armstrong-numbers', testCase), equals('''
+    test('${testCase['description']}', () {
+      final null result = armstrongNumbers.${testCase['property']}(${testCase['input']['number']});
+      expect(result, equals(${testCase['expected']}));
+    }, skip: false);
+'''));
         });
       });
     });

--- a/test/create_exercise_test.dart
+++ b/test/create_exercise_test.dart
@@ -152,7 +152,7 @@ class FooBar {
 import 'package:foo_bar/foo_bar.dart';
 import 'package:test/test.dart';
 
-final fooBar = new FooBar();
+final fooBar = FooBar();
 
 void main() {
   group('FooBar', () {
@@ -229,7 +229,7 @@ linter:
         ];
 
         Set<dynamic> actualSet = retrieveListOfExpected(cases);
-        Set<String> expectedSet = new Set.from(<String>['Hello, World!']);
+        Set<String> expectedSet = Set.from(<String>['Hello, World!']);
 
         expect(actualSet, equals(expectedSet));
       });
@@ -275,7 +275,7 @@ linter:
         ];
 
         Set<dynamic> actualSet = retrieveListOfExpected(cases);
-        Set<bool> expectedSet = new Set.from(<bool>[false, true]);
+        Set<bool> expectedSet = Set.from(<bool>[false, true]);
 
         expect(actualSet, equals(expectedSet));
       });
@@ -297,7 +297,7 @@ linter:
         ];
 
         Set<dynamic> actualSet = retrieveListOfExpected(cases);
-        Set<bool> expectedSet = new Set.from(<bool>[true]);
+        Set<bool> expectedSet = Set.from(<bool>[true]);
 
         expect(actualSet, equals(expectedSet));
       });
@@ -376,7 +376,7 @@ linter:
         ];
 
         Set<dynamic> actualSet = retrieveListOfExpected(cases);
-        Set<int> expectedSet = new Set.from(<int>[1, 225, 25502500, 55, 338350, 0, 170, 25164150]);
+        Set<int> expectedSet = Set.from(<int>[1, 225, 25502500, 55, 338350, 0, 170, 25164150]);
 
         expect(actualSet, equals(expectedSet));
       });
@@ -435,7 +435,7 @@ linter:
         ];
 
         Set<dynamic> actualSet = retrieveListOfExpected(cases);
-        Set<Map<String, dynamic>> expectedSet = new Set.from(<Map<String, dynamic>>[
+        Set<Map<String, dynamic>> expectedSet = Set.from(<Map<String, dynamic>>[
           <String, dynamic>{"data": "4", "left": null, "right": null},
           <String, dynamic>{
             "data": "4",
@@ -468,7 +468,7 @@ linter:
         ];
 
         Set<dynamic> actualSet = retrieveListOfExpected(cases);
-        Set<dynamic> expectedSet = new Set<dynamic>();
+        Set<dynamic> expectedSet = Set<dynamic>();
 
         expect(actualSet, equals(expectedSet));
       });

--- a/test/create_exercise_test.dart
+++ b/test/create_exercise_test.dart
@@ -229,7 +229,7 @@ linter:
         ];
 
         Set<dynamic> actualSet = retrieveListOfExpected(cases);
-        Set<String> expectedSet = Set.from(<String>['Hello, World!']);
+        Set<String> expectedSet = Set.of(['Hello, World!']);
 
         expect(actualSet, equals(expectedSet));
       });
@@ -275,7 +275,7 @@ linter:
         ];
 
         Set<dynamic> actualSet = retrieveListOfExpected(cases);
-        Set<bool> expectedSet = Set.from(<bool>[false, true]);
+        Set<bool> expectedSet = Set.of([false, true]);
 
         expect(actualSet, equals(expectedSet));
       });
@@ -297,7 +297,7 @@ linter:
         ];
 
         Set<dynamic> actualSet = retrieveListOfExpected(cases);
-        Set<bool> expectedSet = Set.from(<bool>[true]);
+        Set<bool> expectedSet = Set.of([true]);
 
         expect(actualSet, equals(expectedSet));
       });
@@ -376,7 +376,7 @@ linter:
         ];
 
         Set<dynamic> actualSet = retrieveListOfExpected(cases);
-        Set<int> expectedSet = Set.from(<int>[1, 225, 25502500, 55, 338350, 0, 170, 25164150]);
+        Set<int> expectedSet = Set.of([1, 225, 25502500, 55, 338350, 0, 170, 25164150]);
 
         expect(actualSet, equals(expectedSet));
       });
@@ -435,7 +435,7 @@ linter:
         ];
 
         Set<dynamic> actualSet = retrieveListOfExpected(cases);
-        Set<Map<String, dynamic>> expectedSet = Set.from(<Map<String, dynamic>>[
+        Set<Map<String, dynamic>> expectedSet = Set.of([
           <String, dynamic>{"data": "4", "left": null, "right": null},
           <String, dynamic>{
             "data": "4",

--- a/test/create_exercise_test.dart
+++ b/test/create_exercise_test.dart
@@ -201,10 +201,10 @@ linter:
       group('testCaseTemplate tests', () {
         test('simple test for a single case', () {
           Map<String, dynamic> testCase = <String, dynamic>{
-            "description": "Zero is an Armstrong number",
-            "property": "isArmstrongNumber",
-            "input": {"number": 0},
-            "expected": true
+            'description': 'Zero is an Armstrong number',
+            'property': 'isArmstrongNumber',
+            'input': {'number': 0},
+            'expected': true
           };
 
           expect(testCaseTemplate('armstrong-numbers', testCase), equals('''
@@ -221,10 +221,10 @@ linter:
       test('single case', () {
         List<Map<String, dynamic>> cases = <Map<String, dynamic>>[
           <String, dynamic>{
-            "description": "Say Hi!",
-            "property": "hello",
-            "input": <String, dynamic>{},
-            "expected": "Hello, World!"
+            'description': 'Say Hi!',
+            'property': 'hello',
+            'input': <String, dynamic>{},
+            'expected': 'Hello, World!'
           }
         ];
 
@@ -237,40 +237,40 @@ linter:
       test('multiple cases', () {
         List<Map<String, dynamic>> cases = <Map<String, dynamic>>[
           <String, dynamic>{
-            "description": "year not divisible by 4 in common year",
-            "property": "leapYear",
-            "input": {"year": 2015},
-            "expected": false
+            'description': 'year not divisible by 4 in common year',
+            'property': 'leapYear',
+            'input': {'year': 2015},
+            'expected': false
           },
           <String, dynamic>{
-            "description": "year divisible by 2, not divisible by 4 in common year",
-            "property": "leapYear",
-            "input": {"year": 1970},
-            "expected": false
+            'description': 'year divisible by 2, not divisible by 4 in common year',
+            'property': 'leapYear',
+            'input': {'year': 1970},
+            'expected': false
           },
           <String, dynamic>{
-            "description": "year divisible by 4, not divisible by 100 in leap year",
-            "property": "leapYear",
-            "input": {"year": 1996},
-            "expected": true
+            'description': 'year divisible by 4, not divisible by 100 in leap year',
+            'property': 'leapYear',
+            'input': {'year': 1996},
+            'expected': true
           },
           <String, dynamic>{
-            "description": "year divisible by 100, not divisible by 400 in common year",
-            "property": "leapYear",
-            "input": {"year": 2100},
-            "expected": false
+            'description': 'year divisible by 100, not divisible by 400 in common year',
+            'property': 'leapYear',
+            'input': {'year': 2100},
+            'expected': false
           },
           <String, dynamic>{
-            "description": "year divisible by 400 in leap year",
-            "property": "leapYear",
-            "input": {"year": 2000},
-            "expected": true
+            'description': 'year divisible by 400 in leap year',
+            'property': 'leapYear',
+            'input': {'year': 2000},
+            'expected': true
           },
           <String, dynamic>{
-            "description": "year divisible by 200, not divisible by 400 in common year",
-            "property": "leapYear",
-            "input": {"year": 1800},
-            "expected": false
+            'description': 'year divisible by 200, not divisible by 400 in common year',
+            'property': 'leapYear',
+            'input': {'year': 1800},
+            'expected': false
           }
         ];
 
@@ -283,14 +283,14 @@ linter:
       test('nested case', () {
         List<Map<String, dynamic>> cases = <Map<String, dynamic>>[
           <String, dynamic>{
-            "description": "Check if the given string is an isogram",
-            "comments": ["Output should be a boolean denoting if the string is a isogram or not."],
-            "cases": [
+            'description': 'Check if the given string is an isogram',
+            'comments': ['Output should be a boolean denoting if the string is a isogram or not.'],
+            'cases': [
               {
-                "description": "empty string",
-                "property": "isIsogram",
-                "input": {"phrase": ""},
-                "expected": true
+                'description': 'empty string',
+                'property': 'isIsogram',
+                'input': {'phrase': ''},
+                'expected': true
               }
             ]
           }
@@ -305,71 +305,71 @@ linter:
       test('three nested cases', () {
         List<Map<String, dynamic>> cases = <Map<String, dynamic>>[
           <String, dynamic>{
-            "description": "Square the sum of the numbers up to the given number",
-            "cases": [
+            'description': 'Square the sum of the numbers up to the given number',
+            'cases': [
               {
-                "description": "square of sum 1",
-                "property": "squareOfSum",
-                "input": {"number": 1},
-                "expected": 1
+                'description': 'square of sum 1',
+                'property': 'squareOfSum',
+                'input': {'number': 1},
+                'expected': 1
               },
               {
-                "description": "square of sum 5",
-                "property": "squareOfSum",
-                "input": {"number": 5},
-                "expected": 225
+                'description': 'square of sum 5',
+                'property': 'squareOfSum',
+                'input': {'number': 5},
+                'expected': 225
               },
               {
-                "description": "square of sum 100",
-                "property": "squareOfSum",
-                "input": {"number": 100},
-                "expected": 25502500
+                'description': 'square of sum 100',
+                'property': 'squareOfSum',
+                'input': {'number': 100},
+                'expected': 25502500
               }
             ]
           },
           <String, dynamic>{
-            "description": "Sum the squares of the numbers up to the given number",
-            "cases": [
+            'description': 'Sum the squares of the numbers up to the given number',
+            'cases': [
               {
-                "description": "sum of squares 1",
-                "property": "sumOfSquares",
-                "input": {"number": 1},
-                "expected": 1
+                'description': 'sum of squares 1',
+                'property': 'sumOfSquares',
+                'input': {'number': 1},
+                'expected': 1
               },
               {
-                "description": "sum of squares 5",
-                "property": "sumOfSquares",
-                "input": {"number": 5},
-                "expected": 55
+                'description': 'sum of squares 5',
+                'property': 'sumOfSquares',
+                'input': {'number': 5},
+                'expected': 55
               },
               {
-                "description": "sum of squares 100",
-                "property": "sumOfSquares",
-                "input": {"number": 100},
-                "expected": 338350
+                'description': 'sum of squares 100',
+                'property': 'sumOfSquares',
+                'input': {'number': 100},
+                'expected': 338350
               }
             ]
           },
           <String, dynamic>{
-            "description": "Subtract sum of squares from square of sums",
-            "cases": [
+            'description': 'Subtract sum of squares from square of sums',
+            'cases': [
               {
-                "description": "difference of squares 1",
-                "property": "differenceOfSquares",
-                "input": {"number": 1},
-                "expected": 0
+                'description': 'difference of squares 1',
+                'property': 'differenceOfSquares',
+                'input': {'number': 1},
+                'expected': 0
               },
               {
-                "description": "difference of squares 5",
-                "property": "differenceOfSquares",
-                "input": {"number": 5},
-                "expected": 170
+                'description': 'difference of squares 5',
+                'property': 'differenceOfSquares',
+                'input': {'number': 5},
+                'expected': 170
               },
               {
-                "description": "difference of squares 100",
-                "property": "differenceOfSquares",
-                "input": {"number": 100},
-                "expected": 25164150
+                'description': 'difference of squares 100',
+                'property': 'differenceOfSquares',
+                'input': {'number': 100},
+                'expected': 25164150
               }
             ]
           }
@@ -384,50 +384,50 @@ linter:
       test('uneven nested cases', () {
         List<Map<String, dynamic>> cases = <Map<String, dynamic>>[
           <String, dynamic>{
-            "description": "data is retained",
-            "property": "data",
-            "input": {
-              "treeData": ["4"]
+            'description': 'data is retained',
+            'property': 'data',
+            'input': {
+              'treeData': ['4']
             },
-            "expected": {"data": "4", "left": null, "right": null}
+            'expected': {'data': '4', 'left': null, 'right': null}
           },
           <String, dynamic>{
-            "description": "insert data at proper node",
-            "cases": [
+            'description': 'insert data at proper node',
+            'cases': [
               {
-                "description": "smaller number at left node",
-                "property": "data",
-                "input": {
-                  "treeData": ["4", "2"]
+                'description': 'smaller number at left node',
+                'property': 'data',
+                'input': {
+                  'treeData': ['4', '2']
                 },
-                "expected": {
-                  "data": "4",
-                  "left": {"data": "2", "left": null, "right": null},
-                  "right": null
+                'expected': {
+                  'data': '4',
+                  'left': {'data': '2', 'left': null, 'right': null},
+                  'right': null
                 }
               },
               {
-                "description": "same number at left node",
-                "property": "data",
-                "input": {
-                  "treeData": ["4", "4"]
+                'description': 'same number at left node',
+                'property': 'data',
+                'input': {
+                  'treeData': ['4', '4']
                 },
-                "expected": {
-                  "data": "4",
-                  "left": {"data": "4", "left": null, "right": null},
-                  "right": null
+                'expected': {
+                  'data': '4',
+                  'left': {'data': '4', 'left': null, 'right': null},
+                  'right': null
                 }
               },
               {
-                "description": "greater number at right node",
-                "property": "data",
-                "input": {
-                  "treeData": ["4", "5"]
+                'description': 'greater number at right node',
+                'property': 'data',
+                'input': {
+                  'treeData': ['4', '5']
                 },
-                "expected": {
-                  "data": "4",
-                  "left": null,
-                  "right": {"data": "5", "left": null, "right": null}
+                'expected': {
+                  'data': '4',
+                  'left': null,
+                  'right': {'data': '5', 'left': null, 'right': null}
                 }
               }
             ]
@@ -436,21 +436,21 @@ linter:
 
         Set<dynamic> actualSet = retrieveListOfExpected(cases);
         Set<Map<String, dynamic>> expectedSet = Set.of([
-          <String, dynamic>{"data": "4", "left": null, "right": null},
+          <String, dynamic>{'data': '4', 'left': null, 'right': null},
           <String, dynamic>{
-            "data": "4",
-            "left": {"data": "2", "left": null, "right": null},
-            "right": null
+            'data': '4',
+            'left': {'data': '2', 'left': null, 'right': null},
+            'right': null
           },
           <String, dynamic>{
-            "data": "4",
-            "left": {"data": "4", "left": null, "right": null},
-            "right": null
+            'data': '4',
+            'left': {'data': '4', 'left': null, 'right': null},
+            'right': null
           },
           <String, dynamic>{
-            "data": "4",
-            "left": null,
-            "right": {"data": "5", "left": null, "right": null}
+            'data': '4',
+            'left': null,
+            'right': {'data': '5', 'left': null, 'right': null}
           }
         ]);
 
@@ -460,10 +460,10 @@ linter:
       test('case with an expected error', () {
         List<Map<String, dynamic>> cases = <Map<String, dynamic>>[
           <String, dynamic>{
-            "description": "zero is an error",
-            "property": "steps",
-            "input": {"number": 0},
-            "expected": {"error": "Only positive numbers are allowed"}
+            'description': 'zero is an error',
+            'property': 'steps',
+            'input': {'number': 0},
+            'expected': {'error': 'Only positive numbers are allowed'}
           }
         ];
 

--- a/test/create_exercise_test.dart
+++ b/test/create_exercise_test.dart
@@ -215,5 +215,262 @@ linter:
         });
       });
     });
+
+    group('processing test cases', () {
+      test('single case', () {
+        List<Map<String, dynamic>> cases = <Map<String, dynamic>>[
+          <String, dynamic>{
+            "description": "Say Hi!",
+            "property": "hello",
+            "input": <String, dynamic>{},
+            "expected": "Hello, World!"
+          }
+        ];
+
+        Set<dynamic> actualSet = retrieveListOfExpected(cases);
+        Set<String> expectedSet = new Set.from(<String>['Hello, World!']);
+
+        expect(actualSet, equals(expectedSet));
+      });
+
+      test('multiple cases', () {
+        List<Map<String, dynamic>> cases = <Map<String, dynamic>>[
+          <String, dynamic>{
+            "description": "year not divisible by 4 in common year",
+            "property": "leapYear",
+            "input": {"year": 2015},
+            "expected": false
+          },
+          <String, dynamic>{
+            "description": "year divisible by 2, not divisible by 4 in common year",
+            "property": "leapYear",
+            "input": {"year": 1970},
+            "expected": false
+          },
+          <String, dynamic>{
+            "description": "year divisible by 4, not divisible by 100 in leap year",
+            "property": "leapYear",
+            "input": {"year": 1996},
+            "expected": true
+          },
+          <String, dynamic>{
+            "description": "year divisible by 100, not divisible by 400 in common year",
+            "property": "leapYear",
+            "input": {"year": 2100},
+            "expected": false
+          },
+          <String, dynamic>{
+            "description": "year divisible by 400 in leap year",
+            "property": "leapYear",
+            "input": {"year": 2000},
+            "expected": true
+          },
+          <String, dynamic>{
+            "description": "year divisible by 200, not divisible by 400 in common year",
+            "property": "leapYear",
+            "input": {"year": 1800},
+            "expected": false
+          }
+        ];
+
+        Set<dynamic> actualSet = retrieveListOfExpected(cases);
+        Set<bool> expectedSet = new Set.from(<bool>[false, true]);
+
+        expect(actualSet, equals(expectedSet));
+      });
+
+      test('nested case', () {
+        List<Map<String, dynamic>> cases = <Map<String, dynamic>>[
+          <String, dynamic>{
+            "description": "Check if the given string is an isogram",
+            "comments": ["Output should be a boolean denoting if the string is a isogram or not."],
+            "cases": [
+              {
+                "description": "empty string",
+                "property": "isIsogram",
+                "input": {"phrase": ""},
+                "expected": true
+              }
+            ]
+          }
+        ];
+
+        Set<dynamic> actualSet = retrieveListOfExpected(cases);
+        Set<bool> expectedSet = new Set.from(<bool>[true]);
+
+        expect(actualSet, equals(expectedSet));
+      });
+
+      test('three nested cases', () {
+        List<Map<String, dynamic>> cases = <Map<String, dynamic>>[
+          <String, dynamic>{
+            "description": "Square the sum of the numbers up to the given number",
+            "cases": [
+              {
+                "description": "square of sum 1",
+                "property": "squareOfSum",
+                "input": {"number": 1},
+                "expected": 1
+              },
+              {
+                "description": "square of sum 5",
+                "property": "squareOfSum",
+                "input": {"number": 5},
+                "expected": 225
+              },
+              {
+                "description": "square of sum 100",
+                "property": "squareOfSum",
+                "input": {"number": 100},
+                "expected": 25502500
+              }
+            ]
+          },
+          <String, dynamic>{
+            "description": "Sum the squares of the numbers up to the given number",
+            "cases": [
+              {
+                "description": "sum of squares 1",
+                "property": "sumOfSquares",
+                "input": {"number": 1},
+                "expected": 1
+              },
+              {
+                "description": "sum of squares 5",
+                "property": "sumOfSquares",
+                "input": {"number": 5},
+                "expected": 55
+              },
+              {
+                "description": "sum of squares 100",
+                "property": "sumOfSquares",
+                "input": {"number": 100},
+                "expected": 338350
+              }
+            ]
+          },
+          <String, dynamic>{
+            "description": "Subtract sum of squares from square of sums",
+            "cases": [
+              {
+                "description": "difference of squares 1",
+                "property": "differenceOfSquares",
+                "input": {"number": 1},
+                "expected": 0
+              },
+              {
+                "description": "difference of squares 5",
+                "property": "differenceOfSquares",
+                "input": {"number": 5},
+                "expected": 170
+              },
+              {
+                "description": "difference of squares 100",
+                "property": "differenceOfSquares",
+                "input": {"number": 100},
+                "expected": 25164150
+              }
+            ]
+          }
+        ];
+
+        Set<dynamic> actualSet = retrieveListOfExpected(cases);
+        Set<int> expectedSet = new Set.from(<int>[1, 225, 25502500, 55, 338350, 0, 170, 25164150]);
+
+        expect(actualSet, equals(expectedSet));
+      });
+
+      test('uneven nested cases', () {
+        List<Map<String, dynamic>> cases = <Map<String, dynamic>>[
+          <String, dynamic>{
+            "description": "data is retained",
+            "property": "data",
+            "input": {
+              "treeData": ["4"]
+            },
+            "expected": {"data": "4", "left": null, "right": null}
+          },
+          <String, dynamic>{
+            "description": "insert data at proper node",
+            "cases": [
+              {
+                "description": "smaller number at left node",
+                "property": "data",
+                "input": {
+                  "treeData": ["4", "2"]
+                },
+                "expected": {
+                  "data": "4",
+                  "left": {"data": "2", "left": null, "right": null},
+                  "right": null
+                }
+              },
+              {
+                "description": "same number at left node",
+                "property": "data",
+                "input": {
+                  "treeData": ["4", "4"]
+                },
+                "expected": {
+                  "data": "4",
+                  "left": {"data": "4", "left": null, "right": null},
+                  "right": null
+                }
+              },
+              {
+                "description": "greater number at right node",
+                "property": "data",
+                "input": {
+                  "treeData": ["4", "5"]
+                },
+                "expected": {
+                  "data": "4",
+                  "left": null,
+                  "right": {"data": "5", "left": null, "right": null}
+                }
+              }
+            ]
+          }
+        ];
+
+        Set<dynamic> actualSet = retrieveListOfExpected(cases);
+        Set<Map<String, dynamic>> expectedSet = new Set.from(<Map<String, dynamic>>[
+          <String, dynamic>{"data": "4", "left": null, "right": null},
+          <String, dynamic>{
+            "data": "4",
+            "left": {"data": "2", "left": null, "right": null},
+            "right": null
+          },
+          <String, dynamic>{
+            "data": "4",
+            "left": {"data": "4", "left": null, "right": null},
+            "right": null
+          },
+          <String, dynamic>{
+            "data": "4",
+            "left": null,
+            "right": {"data": "5", "left": null, "right": null}
+          }
+        ]);
+
+        expect(actualSet, equals(expectedSet));
+      });
+
+      test('case with an expected error', () {
+        List<Map<String, dynamic>> cases = <Map<String, dynamic>>[
+          <String, dynamic>{
+            "description": "zero is an error",
+            "property": "steps",
+            "input": {"number": 0},
+            "expected": {"error": "Only positive numbers are allowed"}
+          }
+        ];
+
+        Set<dynamic> actualSet = retrieveListOfExpected(cases);
+        Set<dynamic> expectedSet = new Set<dynamic>();
+
+        expect(actualSet, equals(expectedSet));
+      });
+    });
   });
 }

--- a/test/exercises_test.dart
+++ b/test/exercises_test.dart
@@ -1,11 +1,11 @@
-import "dart:async";
-import "dart:io";
+import 'dart:async';
+import 'dart:io';
 
-import "package:test/test.dart";
-import "package:yaml/yaml.dart";
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
 
 /// Constants
-const String envName = "EXERCISE";
+const String envName = 'EXERCISE';
 
 /// Helpers
 Future runCmd(List<String> cmds) async {
@@ -26,17 +26,17 @@ Future runCmd(List<String> cmds) async {
 }
 
 Future<String> getPackageName() async {
-  final pubspec = new File("pubspec.yaml");
+  final pubspec = new File('pubspec.yaml');
 
   final String pubspecString = await pubspec.readAsString();
 
-  final String packageName = loadYaml(pubspecString)["name"] as String;
+  final String packageName = loadYaml(pubspecString)['name'] as String;
 
   return packageName;
 }
 
 Future locateExercismDirAndExecuteTests() async {
-  final exercisesRootDir = new Directory("exercises");
+  final exercisesRootDir = new Directory('exercises');
 
   assert(await exercisesRootDir.exists());
 
@@ -59,31 +59,31 @@ Future runTest(String path) async {
 
   String packageName = await getPackageName();
 
-  print("""
+  print('''
 ================================================================================
 Running tests for: $packageName
 ================================================================================
-""");
+''');
 
-  File stub = new File("lib/${packageName}.dart");
-  File example = new File("lib/example.dart");
+  File stub = new File('lib/${packageName}.dart');
+  File example = new File('lib/example.dart');
 
   try {
-    stub = await stub.rename("lib/${packageName}.dart.bu");
-    example = await example.rename("lib/${packageName}.dart");
+    stub = await stub.rename('lib/${packageName}.dart.bu');
+    example = await example.rename('lib/${packageName}.dart');
 
     for (List<String> cmds in [
       /// Pull dependencies
-      ["pub", "upgrade"],
+      ['pub', 'upgrade'],
 
       /// Run all exercise tests
-      ["pub", "run", "test", "--run-skipped"]
+      ['pub', 'run', 'test', '--run-skipped']
     ]) {
       await runCmd(cmds);
     }
   } finally {
-    await example.rename("lib/example.dart");
-    await stub.rename("lib/${packageName}.dart");
+    await example.rename('lib/example.dart');
+    await stub.rename('lib/${packageName}.dart');
 
     Directory.current = current;
   }
@@ -91,7 +91,7 @@ Running tests for: $packageName
 
 /// Execute all the tests under the exercise directory
 Future runAllTests() async {
-  final dartExercismRootDir = new Directory("..");
+  final dartExercismRootDir = new Directory('..');
 
   assert(await dartExercismRootDir.exists());
 
@@ -101,25 +101,25 @@ Future runAllTests() async {
 
   String packageName = await getPackageName();
 
-  print("""
+  print('''
 
 ================================================================================
 Running tests for: $packageName
 ================================================================================
-""");
+''');
 }
 
 void main() {
   final testName = Platform.environment[envName];
 
-  test("Exercises", () async {
+  test('Exercises', () async {
     if (testName == null) {
       await runAllTests();
     } else {
-      final testPath = "${Directory.current.path}/exercises/$testName";
+      final testPath = '${Directory.current.path}/exercises/$testName';
 
       if (!await new Directory(testPath).exists()) {
-        throw new ArgumentError("No exercise with this name: $testName");
+        throw new ArgumentError('No exercise with this name: $testName');
       }
 
       await runTest(testPath);


### PR DESCRIPTION
The create_exercise script needed to be updated to handle a few things:
- [x] pubspec.yaml template was out of date
- [x] test template was out of date
- [x] test template should sort the imports alphabetically
- [x] The script should use the latest version of dart_style so the formatting is leveraging the latest lint rules or updates to existing lint rules.
- [x] The Dart style guide suggests using single quotes, so the script needs to be able to use them for strings and then handle cases where an apostrophe (') is used within a string.
- [x] When detecting an integer the script should be able to select `num`, `int`, or `double` as necessary.
- [x] In some cases when a test case is generated, the expected value is an empty List. However, the script needs to know what type of object is in the List and currently can't determine what the type is.
- [X] The generator handles strings with the `\n` escape sequence, it needs to handle more escape sequences.
- [x] For matching brackets: fails to generate necessary backslashes `\` for last test
- [x] Check the version number before re-generating the exercise
