### PR TITLE
.gitignore: Add rule to exclude IDE files/folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 bin/configlet
 bin/configlet.exe
 
-
 ### Dart ###
 # Directory created by dart tools
 /exercises/**/pubspec.lock
@@ -22,3 +21,7 @@ doc/
 *.js.deps
 *.js.map
 *.info.json
+
+## IDE files/folders
+/.idea/
+/.vscode/


### PR DESCRIPTION
@exercism/dart @amscotti 

Are there any other IDE files/folders we could ignore to make it easier for you?