### PR TITLE
Adds resistor-color exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -19,6 +19,17 @@
       ]
     },
     {
+      "slug": "resistor-color",
+      "uuid": "b0e61aa6-5944-48b4-a91b-8960b6655e51",
+      "core": false,
+      "unlocked_by": "hello-world",
+      "difficulty": 2,
+      "topics": [
+        "arrays",
+        "strings"
+      ]
+    },
+    {
       "slug": "two-fer",
       "uuid": "57a75d7e-370b-4937-8dd4-429db1f26ff3",
       "core": true,

--- a/exercises/resistor-color/README.md
+++ b/exercises/resistor-color/README.md
@@ -1,0 +1,36 @@
+# Resistor Color
+
+Resistors have color coded bands, where each color maps to a number. The first 2 bands of a resistor have a simple encoding scheme: each color maps to a single number.
+
+These colors are encoded as follows:
+
+- Black: 0
+- Brown: 1
+- Red: 2
+- Orange: 3
+- Yellow: 4
+- Green: 5
+- Blue: 6
+- Violet: 7
+- Grey: 8
+- White: 9
+
+Mnemonics map the colors to the numbers, that, when stored as an array, happen to map to their index in the array: Better Be Right Or Your Great Big Values Go Wrong.
+
+More information on the color encoding of resistors can be found in the [Electronic color code Wikipedia article](https://en.wikipedia.org/wiki/Electronic_color_code)
+
+
+To run the tests:
+
+```sh
+$ pub run test
+```
+
+For more detailed info about the Dart track see the [installation](http://exercism.io/languages/dart/installation) and [testing](http://exercism.io/languages/dart/tests) pages.
+
+## Source
+
+Maud de Vries, Erik Schierboom [https://github.com/exercism/problem-specifications/issues/1458](https://github.com/exercism/problem-specifications/issues/1458)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/resistor-color/analysis_options.yaml
+++ b/exercises/resistor-color/analysis_options.yaml
@@ -1,0 +1,18 @@
+analyzer:
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false
+  errors:
+    unused_element:        error
+    unused_import:         error
+    unused_local_variable: error
+    dead_code:             error
+
+linter:
+  rules:
+    # Error Rules
+    - avoid_relative_lib_imports
+    - avoid_types_as_parameter_names
+    - literal_only_boolean_expressions
+    - no_adjacent_strings_in_list
+    - valid_regexps

--- a/exercises/resistor-color/lib/example.dart
+++ b/exercises/resistor-color/lib/example.dart
@@ -1,0 +1,5 @@
+class ResistorColor {
+  final colors = ["black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white"];
+
+  int colorCode(String color) => colors.indexOf(color);
+}

--- a/exercises/resistor-color/lib/resistor_color.dart
+++ b/exercises/resistor-color/lib/resistor_color.dart
@@ -1,0 +1,3 @@
+class ResistorColor {
+  // Put your code here
+}

--- a/exercises/resistor-color/pubspec.yaml
+++ b/exercises/resistor-color/pubspec.yaml
@@ -1,0 +1,5 @@
+name: 'resistor_color'
+environment:
+  sdk: ">=1.24.0 <3.0.0"
+dev_dependencies:
+  test: '<2.0.0'

--- a/exercises/resistor-color/test/resistor_color_test.dart
+++ b/exercises/resistor-color/test/resistor_color_test.dart
@@ -1,0 +1,30 @@
+import 'package:resistor_color/resistor_color.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final resistorColor = new ResistorColor();
+
+  group('ResistorColor', () {
+    group('Color codes', () {
+      test("Black", () {
+        final int result = resistorColor.colorCode("black");
+        expect(result, equals(0));
+      }, skip: false);
+
+      test("White", () {
+        final int result = resistorColor.colorCode("white");
+        expect(result, equals(9));
+      }, skip: true);
+
+      test("Orange", () {
+        final int result = resistorColor.colorCode("orange");
+        expect(result, equals(3));
+      }, skip: true);
+    });
+
+    test("Colors", () {
+      final List<String> result = resistorColor.colors;
+      expect(result, equals(["black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white"]));
+    }, skip: true);
+  });
+}


### PR DESCRIPTION
Hi, this PR is to add a new exercise for `resistor-color`, [here is a link to the problem-specifications](https://github.com/exercism/problem-specifications/tree/master/exercises/resistor-color)

I'm still learning Dart, so feel free to point out anything that needs to be change or improved. I'm also happy to change the `config.json` to better fit your layout for the track.

Thanks! :)