### PR TITLE
Adds resistor-color-duo exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -42,6 +42,17 @@
       ]
     },
     {
+      "slug": "resistor-color-duo",
+      "uuid": "98ae146a-67f9-49ae-9cd6-00882a374248",
+      "core": false,
+      "unlocked_by": "two-fer",
+      "difficulty": 2,
+      "topics": [
+        "arrays",
+        "strings"
+      ]
+    },
+    {
       "slug": "reverse-string",
       "uuid": "f195282c-c7a3-4a85-bbc1-d4e85e62d54c",
       "core": false,

--- a/exercises/resistor-color-duo/README.md
+++ b/exercises/resistor-color-duo/README.md
@@ -1,0 +1,38 @@
+# Resistor Color Duo
+
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_. For this exercise, you need to know two things about them:
+
+* Each resistor has a resistance value.
+* Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values. Each band acts as a digit of a number. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
+
+In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take two colors as input, and output the correct number.
+
+The band colors are encoded as follows:
+
+- Black: 0
+- Brown: 1
+- Red: 2
+- Orange: 3
+- Yellow: 4
+- Green: 5
+- Blue: 6
+- Violet: 7
+- Grey: 8
+- White: 9
+
+
+To run the tests:
+
+```sh
+$ pub run test
+```
+
+For more detailed info about the Dart track see the [installation](http://exercism.io/languages/dart/installation) and [testing](http://exercism.io/languages/dart/tests) pages.
+
+## Source
+
+Maud de Vries, Erik Schierboom [https://github.com/exercism/problem-specifications/issues/1464](https://github.com/exercism/problem-specifications/issues/1464)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/resistor-color-duo/analysis_options.yaml
+++ b/exercises/resistor-color-duo/analysis_options.yaml
@@ -1,0 +1,18 @@
+analyzer:
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false
+  errors:
+    unused_element:        error
+    unused_import:         error
+    unused_local_variable: error
+    dead_code:             error
+
+linter:
+  rules:
+    # Error Rules
+    - avoid_relative_lib_imports
+    - avoid_types_as_parameter_names
+    - literal_only_boolean_expressions
+    - no_adjacent_strings_in_list
+    - valid_regexps

--- a/exercises/resistor-color-duo/lib/example.dart
+++ b/exercises/resistor-color-duo/lib/example.dart
@@ -1,0 +1,5 @@
+class ResistorColorDuo {
+  final colors = ["black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white"];
+
+  int value(List<String> input) => int.parse(input.map(colors.indexOf).join());
+}

--- a/exercises/resistor-color-duo/lib/resistor_color_duo.dart
+++ b/exercises/resistor-color-duo/lib/resistor_color_duo.dart
@@ -1,0 +1,3 @@
+class ResistorColorDuo {
+  // Put your code here
+}

--- a/exercises/resistor-color-duo/pubspec.yaml
+++ b/exercises/resistor-color-duo/pubspec.yaml
@@ -1,0 +1,5 @@
+name: 'resistor_color_duo'
+environment:
+  sdk: ">=1.24.0 <3.0.0"
+dev_dependencies:
+  test: '<2.0.0'

--- a/exercises/resistor-color-duo/test/resistor_color_duo_test.dart
+++ b/exercises/resistor-color-duo/test/resistor_color_duo_test.dart
@@ -1,0 +1,28 @@
+import 'package:resistor_color_duo/resistor_color_duo.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final resistorColorDuo = new ResistorColorDuo();
+
+  group('ResistorColorDuo', () {
+    test("Brown and black", () {
+      final int result = resistorColorDuo.value(["brown", "black"]);
+      expect(result, equals(10));
+    }, skip: false);
+
+    test("Blue and grey", () {
+      final int result = resistorColorDuo.value(["blue", "grey"]);
+      expect(result, equals(68));
+    }, skip: true);
+
+    test("Yellow and violet", () {
+      final int result = resistorColorDuo.value(["yellow", "violet"]);
+      expect(result, equals(47));
+    }, skip: true);
+
+    test("Orange and orange", () {
+      final int result = resistorColorDuo.value(["orange", "orange"]);
+      expect(result, equals(33));
+    }, skip: true);
+  });
+}


### PR DESCRIPTION
Hi, this PR is to add a new exercise for `resistor-color-duo`, [here is a link to the problem-specifications](https://github.com/exercism/problem-specifications/tree/master/exercises/resistor-color-duo)

I'm still learning Dart, so feel free to point out anything that needs to be change or improved. I'm also happy to change the `config.json` to better fit your layout for the track.

Thanks! :)