### PR TITLE
Set inactive maintainers as alumni

### DIFF
--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -3,7 +3,7 @@
   "maintainers": [
     {
       "github_username": "SuperPaintman",
-      "alumnus": false,
+      "alumnus": true,
       "show_on_website": false,
       "name": null,
       "link_text": null,
@@ -23,7 +23,7 @@
     },
     {
       "github_username": "fwip",
-      "alumnus": false,
+      "alumnus": true,
       "show_on_website": false,
       "name": null,
       "link_text": null,


### PR DESCRIPTION
@SuperPaintman hasn't contributed since I got involved in this project and @fwip contibuted since 2017.

So I suggest we set their maintainer status as alumni. I'm not exactly sure what the implications are, but overall I believe it means they moved on from the project. @iHiD correct me if I'm wrong.