### PR TITLE
Update check_formatting with new format option

### DIFF
--- a/bin/check_formatting.dart
+++ b/bin/check_formatting.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'package:exercism_dart/src/utils.dart';
 
 Future main() async {
-  final CommonUtils utils = new CommonUtils();
+  final CommonUtils utils = CommonUtils();
   int errorCode = 0;
 
   if (utils.fetchConfiglet() == 0) {
@@ -12,7 +12,7 @@ Future main() async {
     if (errorCode != 0) {
       print('Checking config.json formatting failed!!');
       await utils.terminate();
-      throw new StateError('Formatting failed.');
+      throw StateError('Formatting failed.');
     }
   }
 
@@ -23,7 +23,7 @@ Future main() async {
   if (errorCode != 0) {
     print('Checking exercise formatting failed!!');
     await utils.terminate();
-    throw new StateError('Formatting failed.');
+    throw StateError('Formatting failed.');
   }
 
   await utils.terminate();

--- a/bin/check_formatting.dart
+++ b/bin/check_formatting.dart
@@ -18,7 +18,7 @@ Future main() async {
 
   print('Checking all Dart files formatting...');
   errorCode = await utils
-      .runCmd('pub', ['run', 'dart_style:format', 'i', '0', '-l', '120', '-n', '--set-exit-if-changed', '.']);
+      .runCmd('pub', ['run', 'dart_style:format', '-i', '0', '-l', '120', '-n', '--set-exit-if-changed', '.']);
 
   if (errorCode != 0) {
     print('Checking exercise formatting failed!!');

--- a/bin/check_formatting.dart
+++ b/bin/check_formatting.dart
@@ -17,7 +17,8 @@ Future main() async {
   }
 
   print('Checking all Dart files formatting...');
-  errorCode = await utils.runCmd('pub', ['run', 'dart_style:format', '-l', '120', '-n', '--set-exit-if-changed', '.']);
+  errorCode = await utils
+      .runCmd('pub', ['run', 'dart_style:format', 'i', '0', '-l', '120', '-n', '--set-exit-if-changed', '.']);
 
   if (errorCode != 0) {
     print('Checking exercise formatting failed!!');

--- a/bin/presubmit.dart
+++ b/bin/presubmit.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'package:exercism_dart/src/utils.dart';
 
 Future<Null> main() async {
-  final CommonUtils utils = new CommonUtils();
+  final CommonUtils utils = CommonUtils();
 
   if (utils.fetchConfiglet() == 0) {
     print('Formatting config.json...');

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -6,13 +6,13 @@ class CommonUtils {
   ProcessManager _manager;
 
   CommonUtils() {
-    this._manager = new ProcessManager();
+    this._manager = ProcessManager();
   }
 
   /// Fetches the configlet file if it doesn't exist already, and returns the
   /// exit code.
   int fetchConfiglet() {
-    File configletFile = new File('bin/configlet');
+    File configletFile = File('bin/configlet');
 
     if (!configletFile.existsSync()) {
       print('Fetching configlet...');
@@ -39,7 +39,7 @@ class CommonUtils {
 
     if (result is bool && !result || result is Future && !await result) {
       print('Unable to run "$executable". Make sure that it\'s executable and that you have permissions to run it.');
-      return new Future.value(1);
+      return Future.value(1);
     }
 
     return runCmd(executable, arguments);

--- a/test/exercises_test.dart
+++ b/test/exercises_test.dart
@@ -26,7 +26,7 @@ Future runCmd(List<String> cmds) async {
 }
 
 Future<String> getPackageName() async {
-  final pubspec = new File('pubspec.yaml');
+  final pubspec = File('pubspec.yaml');
 
   final String pubspecString = await pubspec.readAsString();
 
@@ -36,7 +36,7 @@ Future<String> getPackageName() async {
 }
 
 Future locateExercismDirAndExecuteTests() async {
-  final exercisesRootDir = new Directory('exercises');
+  final exercisesRootDir = Directory('exercises');
 
   assert(await exercisesRootDir.exists());
 
@@ -65,8 +65,8 @@ Running tests for: $packageName
 ================================================================================
 ''');
 
-  File stub = new File('lib/${packageName}.dart');
-  File example = new File('lib/example.dart');
+  File stub = File('lib/${packageName}.dart');
+  File example = File('lib/example.dart');
 
   try {
     stub = await stub.rename('lib/${packageName}.dart.bu');
@@ -91,7 +91,7 @@ Running tests for: $packageName
 
 /// Execute all the tests under the exercise directory
 Future runAllTests() async {
-  final dartExercismRootDir = new Directory('..');
+  final dartExercismRootDir = Directory('..');
 
   assert(await dartExercismRootDir.exists());
 
@@ -118,11 +118,11 @@ void main() {
     } else {
       final testPath = '${Directory.current.path}/exercises/$testName';
 
-      if (!await new Directory(testPath).exists()) {
-        throw new ArgumentError('No exercise with this name: $testName');
+      if (!await Directory(testPath).exists()) {
+        throw ArgumentError('No exercise with this name: $testName');
       }
 
       await runTest(testPath);
     }
-  }, timeout: new Timeout(new Duration(minutes: 20)));
+  }, timeout: Timeout(Duration(minutes: 20)));
 }


### PR DESCRIPTION
Add another argument to the check_formatting's use of dart_style. The `-i` argument defines the number of spaces to have for leading indentations.

Additionally, I took the opportunity to format the bin, lib, and test files using [dart_style's `--fix` argument](https://github.com/dart-lang/dart_style/blob/master/bin/format.dart#L40) which applies all the style fixes such as dropping use of `new` and `const` keywords and other small details.

This will help ensure our code's style is idiomatic. As the exercises are updated, I'll format them with the `--fix` argument so that we don't have one PR that formats everything.