### PR TITLE
resistor-color: Revise exercise with updates to the specification

### DIFF
--- a/exercises/resistor-color/pubspec.yaml
+++ b/exercises/resistor-color/pubspec.yaml
@@ -1,4 +1,5 @@
 name: 'resistor_color'
+version: 1.0.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/resistor-color/test/resistor_color_test.dart
+++ b/exercises/resistor-color/test/resistor_color_test.dart
@@ -1,30 +1,43 @@
 import 'package:resistor_color/resistor_color.dart';
 import 'package:test/test.dart';
 
-void main() {
-  final resistorColor = new ResistorColor();
+final resistorColor = ResistorColor();
 
+void main() {
   group('ResistorColor', () {
     group('Color codes', () {
-      test("Black", () {
-        final int result = resistorColor.colorCode("black");
+      test('Black', () {
+        final int result = resistorColor.colorCode('black');
         expect(result, equals(0));
       }, skip: false);
 
-      test("White", () {
-        final int result = resistorColor.colorCode("white");
+      test('White', () {
+        final int result = resistorColor.colorCode('white');
         expect(result, equals(9));
       }, skip: true);
 
-      test("Orange", () {
-        final int result = resistorColor.colorCode("orange");
+      test('Orange', () {
+        final int result = resistorColor.colorCode('orange');
         expect(result, equals(3));
       }, skip: true);
     });
 
-    test("Colors", () {
+    test('Colors', () {
       final List<String> result = resistorColor.colors;
-      expect(result, equals(["black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white"]));
+      expect(
+          result,
+          equals(<String>[
+            'black',
+            'brown',
+            'red',
+            'orange',
+            'yellow',
+            'green',
+            'blue',
+            'violet',
+            'grey',
+            'white',
+          ]));
     }, skip: true);
   });
 }


### PR DESCRIPTION
Per #210, ran create_exercise to update resistor-color and add the version to pubspec.yaml