### PR TITLE
resistor-color-duo: Revise exercise with updates to the specification

### DIFF
--- a/exercises/resistor-color-duo/README.md
+++ b/exercises/resistor-color-duo/README.md
@@ -4,9 +4,10 @@ If you want to build something using a Raspberry Pi, you'll probably use _resist
 
 * Each resistor has a resistance value.
 * Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
-To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values. Each band acts as a digit of a number. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
+To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values. Each band has a position and a numeric value. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
 
-In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take two colors as input, and output the correct number.
+In this exercise you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take color names as input and output a two digit number, even if the input is more than two colors!
+
 
 The band colors are encoded as follows:
 
@@ -20,6 +21,11 @@ The band colors are encoded as follows:
 - Violet: 7
 - Grey: 8
 - White: 9
+
+From the example above:
+brown-green should return 15
+brown-green-violet should return 15 too, ignoring the third color.
+
 
 
 To run the tests:

--- a/exercises/resistor-color-duo/lib/example.dart
+++ b/exercises/resistor-color-duo/lib/example.dart
@@ -1,5 +1,8 @@
 class ResistorColorDuo {
-  final colors = ["black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white"];
+  final colors = ['black', 'brown', 'red', 'orange', 'yellow', 'green', 'blue', 'violet', 'grey', 'white'];
 
-  int value(List<String> input) => int.parse(input.map(colors.indexOf).join());
+  int value(List<String> input) {
+    if (input.length > 2) input.removeLast();
+    return int.parse(input.map(colors.indexOf).join());
+  }
 }

--- a/exercises/resistor-color-duo/pubspec.yaml
+++ b/exercises/resistor-color-duo/pubspec.yaml
@@ -1,4 +1,5 @@
 name: 'resistor_color_duo'
+version: 2.1.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/resistor-color-duo/test/resistor_color_duo_test.dart
+++ b/exercises/resistor-color-duo/test/resistor_color_duo_test.dart
@@ -1,28 +1,33 @@
 import 'package:resistor_color_duo/resistor_color_duo.dart';
 import 'package:test/test.dart';
 
-void main() {
-  final resistorColorDuo = new ResistorColorDuo();
+final resistorColorDuo = ResistorColorDuo();
 
+void main() {
   group('ResistorColorDuo', () {
-    test("Brown and black", () {
-      final int result = resistorColorDuo.value(["brown", "black"]);
+    test('Brown and black', () {
+      final int result = resistorColorDuo.value(<String>['brown', 'black']);
       expect(result, equals(10));
     }, skip: false);
 
-    test("Blue and grey", () {
-      final int result = resistorColorDuo.value(["blue", "grey"]);
+    test('Blue and grey', () {
+      final int result = resistorColorDuo.value(<String>['blue', 'grey']);
       expect(result, equals(68));
     }, skip: true);
 
-    test("Yellow and violet", () {
-      final int result = resistorColorDuo.value(["yellow", "violet"]);
+    test('Yellow and violet', () {
+      final int result = resistorColorDuo.value(<String>['yellow', 'violet']);
       expect(result, equals(47));
     }, skip: true);
 
-    test("Orange and orange", () {
-      final int result = resistorColorDuo.value(["orange", "orange"]);
+    test('Orange and orange', () {
+      final int result = resistorColorDuo.value(<String>['orange', 'orange']);
       expect(result, equals(33));
+    }, skip: true);
+
+    test('Ignore additional colors', () {
+      final int result = resistorColorDuo.value(<String>['green', 'brown', 'orange']);
+      expect(result, equals(51));
     }, skip: true);
   });
 }


### PR DESCRIPTION
Per #210, ran create_exercise to update resistor-color-duo and add the version to pubspec.yaml