### PR TITLE
Bump triangle example

### DIFF
--- a/exercises/triangle/test/triangle_test.dart
+++ b/exercises/triangle/test/triangle_test.dart
@@ -1,9 +1,9 @@
 import 'package:test/test.dart';
 import 'package:triangle/triangle.dart';
 
-void main() {
-  final triangle = new Triangle();
+final triangle = Triangle();
 
+void main() {
   group('Triangle', () {
     group('equilateral triangle', () {
       test('all sides are equal', () {


### PR DESCRIPTION
Updates the triangle example for #210 

The examples have stayed the same in the problem-specifications repository, but the test cases in the `canonical-data.json` seem to specify the input as an array of numbers. Looking through the git history, it appears that this exercise in the dart track originally implemented the methods to take 3 `num` parameters instead of an array, even though the canonical-data always specified an array. I decided to keep this for now since it seems like a better interface for methods about triangles. 

It also appears that the `version` was removed from this exercise in the problem specifications and the `create-exercise` script attempts to add `version: null` to the `pubspec.yml`. I removed this since it didn't seem helpful, but I can add it back if that is desired.