### PR TITLE
Add fetch canonical data syncer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 .project
 bin/configlet
 bin/configlet.exe
+bin/canonical_data_syncer
+bin/canonical_data_syncer.exe
 
 ### Dart ###
 # Directory created by dart tools

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,9 @@ Please keep the following in mind:
 - All Exercism exercises must be defined in [problem-specifications](https://github.com/exercism/problem-specifications/tree/master/exercises) before they are implemented for a specific track. If your exercise is new, please submit a PR to [exercism/problem-specification](https://github.com/exercism/problem-specifications).
 
 - Please make sure the new exercise conforms to specifications in the [exercism/problem-specifications](https://github.com/exercism/problem-specifications) repo.
+  - Run `bin/fetch-canonical_data_syncer` to download the canonical_data_syncer.
+  - Use `bin/canonical_data_syncer --exercise <slug-name-for-new-exercise> --mode -c` to see if any test cases are missing.
+    - Example `./bin/canonical_data_syncer --exercise armstrong-numbers --mode -c`
 
 - Each exercise must stand on its own. Do not reference files outside the exercise directory. They will not be included when the user fetches the exercise.
 
@@ -53,8 +56,8 @@ Please keep the following in mind:
 - Each exercise should have a test suite, an example solution, a template file for the real implementation, and a README.md
   - The CI build expects Dart files to be named in the convention of snake_case_filenames
 
-- Please do not commit any configuration files or directories inside the exercise other than pubspec.lock and pubspec.yaml
+- Please do not commit any configuration files or directories inside the exercise other than pubspec.yaml, .meta/tests.toml, and analysis_options.yaml.
 
 - Be sure to add the new exercise to the appropriate place in the `config.json` file.
 
-- Please run `bin/fetch-configlet && bin/configlet lint --track-id=dart .` to ensure the exercise is configured correctly.
+- Please run `bin/fetch-configlet && bin/configlet lint --track-id=dart .` to configure the exercise correctly.

--- a/bin/fetch-canonical_data_syncer
+++ b/bin/fetch-canonical_data_syncer
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -eo pipefail
+
+readonly LATEST='https://api.github.com/repos/exercism/canonical-data-syncer/releases/latest'
+
+case "$(uname)" in
+    (Darwin*)   OS='mac'     ;;
+    (Linux*)    OS='linux'   ;;
+    (Windows*)  OS='windows' ;;
+    (MINGW*)    OS='windows' ;;
+    (MSYS_NT-*) OS='windows' ;;
+    (*)         OS='linux'   ;;
+esac
+
+case "$OS" in
+    (windows*) EXT='zip' ;;
+    (*)        EXT='tgz' ;;
+esac
+
+case "$(uname -m)" in
+    (*64*)  ARCH='64bit' ;;
+    (*686*) ARCH='32bit' ;;
+    (*386*) ARCH='32bit' ;;
+    (*)     ARCH='64bit' ;;
+esac
+
+if [ -z "${GITHUB_TOKEN}" ]
+then
+    HEADER=''
+else
+    HEADER="authorization: Bearer ${GITHUB_TOKEN}"
+fi
+
+FILENAME="canonical_data_syncer-${OS}-${ARCH}.${EXT}"
+
+get_url () {
+    curl --header "$HEADER" -s "$LATEST" |
+        awk -v filename=$FILENAME '$1 ~ /browser_download_url/ && $2 ~ filename { print $2 }' |
+        tr -d '"'
+}
+
+URL=$(get_url)
+
+case "$EXT" in
+    (*zip)
+        curl --header "$HEADER" -s --location "$URL" -o bin/latest-canonical_data_syncer.zip
+        unzip bin/latest-canonical_data_syncer.zip -d bin/
+        rm bin/latest-canonical_data_syncer.zip
+        ;;
+    (*) curl --header "$HEADER" -s --location "$URL" | tar xz -C bin/ ;;
+esac

--- a/bin/fetch-canonical_data_syncer.ps1
+++ b/bin/fetch-canonical_data_syncer.ps1
@@ -1,0 +1,24 @@
+Function DownloadUrl ([string] $FileName, $Headers) {
+    $latestUrl = "https://api.github.com/repos/exercism/canonical-data-syncer/releases/latest"
+    $json = Invoke-RestMethod -Headers $Headers -Uri $latestUrl
+    $json.assets | Where-Object { $_.browser_download_url -match $FileName } | Select-Object -ExpandProperty browser_download_url
+}
+
+Function Headers {
+    If ($GITHUB_TOKEN) { @{ Authorization = "Bearer ${GITHUB_TOKEN}" } } Else { @{ } }
+}
+
+Function Arch {
+    If ([Environment]::Is64BitOperatingSystem) { "64bit" } Else { "32bit" }
+}
+
+$arch = Arch
+$headers = Headers
+$fileName = "canonical_data_syncer-windows-$arch.zip"
+$outputDirectory = "bin"
+$outputFile = Join-Path -Path $outputDirectory -ChildPath $fileName
+$zipUrl = DownloadUrl -FileName $fileName -Headers $headers
+
+Invoke-WebRequest -Headers $headers -Uri $zipUrl -OutFile $outputFile
+Expand-Archive $outputFile -DestinationPath $outputDirectory -Force
+Remove-Item -Path $outputFile


### PR DESCRIPTION
Adding a tool to allow contributors to fetch the newest tool for helping tracks keep their exercise-specific tests.toml files in sync with the latest canonical data in the problem-specifications repo.