### PR TITLE
Remove version parameter all pubspec.yaml for exercises

### DIFF
--- a/exercises/acronym/pubspec.yaml
+++ b/exercises/acronym/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'acronym'
-version: 1.7.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/allergies/pubspec.yaml
+++ b/exercises/allergies/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'allergies'
-version: 2.0.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/anagram/pubspec.yaml
+++ b/exercises/anagram/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'anagram'
-version: 1.5.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/armstrong-numbers/pubspec.yaml
+++ b/exercises/armstrong-numbers/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'armstrong_numbers'
-version: 1.1.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/beer-song/pubspec.yaml
+++ b/exercises/beer-song/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'beer_song'
-version: '2.1.0'
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/binary-search-tree/pubspec.yaml
+++ b/exercises/binary-search-tree/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'binary_search_tree'
-version: 1.0.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/bob/pubspec.yaml
+++ b/exercises/bob/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'bob'
-version: 1.6.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/difference-of-squares/pubspec.yaml
+++ b/exercises/difference-of-squares/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'difference_of_squares'
-version: 1.2.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/gigasecond/pubspec.yaml
+++ b/exercises/gigasecond/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'gigasecond'
-version: 2.0.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/hamming/pubspec.yaml
+++ b/exercises/hamming/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'hamming'
-version: 2.3.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/hello-world/pubspec.yaml
+++ b/exercises/hello-world/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'hello_world'
-version: 1.1.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/isbn-verifier/pubspec.yaml
+++ b/exercises/isbn-verifier/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'isbn_verifier'
-version: 2.7.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/leap/pubspec.yaml
+++ b/exercises/leap/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'leap'
-version: 1.6.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/pascals-triangle/pubspec.yaml
+++ b/exercises/pascals-triangle/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'pascals_triangle'
-version: 1.5.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/phone-number/pubspec.yaml
+++ b/exercises/phone-number/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'phone_number'
-version: 1.7.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/raindrops/pubspec.yaml
+++ b/exercises/raindrops/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'raindrops'
-version: 1.1.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/resistor-color-duo/pubspec.yaml
+++ b/exercises/resistor-color-duo/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'resistor_color_duo'
-version: 2.1.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/resistor-color/pubspec.yaml
+++ b/exercises/resistor-color/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'resistor_color'
-version: 1.0.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/reverse-string/pubspec.yaml
+++ b/exercises/reverse-string/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'reverse_string'
-version: 1.2.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/rna-transcription/pubspec.yaml
+++ b/exercises/rna-transcription/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'rna_transcription'
-version: 1.3.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/robot-simulator/pubspec.yaml
+++ b/exercises/robot-simulator/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'robot_simulator'
-version: 3.2.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/scrabble-score/pubspec.yaml
+++ b/exercises/scrabble-score/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'scrabble_score'
-version: 1.1.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/space-age/pubspec.yaml
+++ b/exercises/space-age/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'space_age'
-version: 1.2.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/two-fer/pubspec.yaml
+++ b/exercises/two-fer/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'two_fer'
-version: 1.2.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:

--- a/exercises/word-count/pubspec.yaml
+++ b/exercises/word-count/pubspec.yaml
@@ -1,5 +1,4 @@
 name: 'word_count'
-version: 1.4.0
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dev_dependencies:


### PR DESCRIPTION
With the move away from versions for problem specs and towards uuids for each test case, we need to remove the existing version parameters.