### PR TITLE
Pin CI to latest stable Dart `2.10` & prepare for NNBD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        tag: [latest, dev]
+
     container:
-      image:  google/dart:latest
+      image:  google/dart:${{ matrix.tag }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,14 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
-      fail-fast: false
       matrix:
-        tag: [latest, dev]
+        tag: ['2.10', latest]
+        experimental: [false]
+        include:
+          - tag: dev
+            experimental: true
 
     container:
       image:  google/dart:${{ matrix.tag }}
@@ -17,11 +20,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Upgrade dependencies
+      if: ${{ matrix.experimental }}
+      run: dart pub upgrade
+
     - name: Install dependencies
-      run: pub get
+      if: ${{ !matrix.experimental }}
+      run: dart pub get
 
     - name: Check Stage formatting
-      run: pub run bin/check_formatting.dart
+      run: dart run bin/check_formatting.dart
 
     - name: Run tests
-      run: pub run test
+      run: dart test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,12 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Upgrade dependencies
-      if: ${{ matrix.experimental }}
-      run: dart pub upgrade
-
     - name: Install dependencies
-      if: ${{ !matrix.experimental }}
       run: dart pub get
 
     - name: Check Stage formatting

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,14 +5,10 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
-        tag: ['2.10', latest]
-        experimental: [false]
-        include:
-          - tag: dev
-            experimental: true
+        tag: ['2.10']
 
     container:
       image:  google/dart:${{ matrix.tag }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         tag: [latest, dev]
 


### PR DESCRIPTION
* Added `matrix` with `latest` and `dev` tags
* Disabled `fail-fast` for now

Closes #270