### PR TITLE
fetch-canonical_data_syncer: Download v0.17.0, not latest

### DIFF
--- a/bin/fetch-canonical_data_syncer
+++ b/bin/fetch-canonical_data_syncer
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-readonly LATEST='https://api.github.com/repos/exercism/canonical-data-syncer/releases/latest'
+readonly FINAL_RELEASE='https://api.github.com/repos/exercism/canonical-data-syncer/releases/33439231' # v0.17.0
 
 case "$(uname)" in
     (Darwin*)   OS='mac'     ;;
@@ -35,7 +35,7 @@ fi
 FILENAME="canonical_data_syncer-${OS}-${ARCH}.${EXT}"
 
 get_url () {
-    curl --header "$HEADER" -s "$LATEST" |
+    curl --header "$HEADER" -s --location "${FINAL_RELEASE}" |
         awk -v filename=$FILENAME '$1 ~ /browser_download_url/ && $2 ~ filename { print $2 }' |
         tr -d '"'
 }

--- a/bin/fetch-canonical_data_syncer.ps1
+++ b/bin/fetch-canonical_data_syncer.ps1
@@ -1,6 +1,6 @@
 Function DownloadUrl ([string] $FileName, $Headers) {
-    $latestUrl = "https://api.github.com/repos/exercism/canonical-data-syncer/releases/latest"
-    $json = Invoke-RestMethod -Headers $Headers -Uri $latestUrl
+    $finalReleaseUrl = "https://api.github.com/repos/exercism/canonical-data-syncer/releases/33439231" # v0.17.0
+    $json = Invoke-RestMethod -Headers $Headers -Uri $finalReleaseUrl
     $json.assets | Where-Object { $_.browser_download_url -match $FileName } | Select-Object -ExpandProperty browser_download_url
 }
 


### PR DESCRIPTION
Pinging @ErikSchierboom - could you please check the changes to the Powershell script? In particular, I'm led to believe that it already follows redirects (we needed to add `--location` in the bash script), but I haven't tested it.

---

This commit alters the `fetch-canonical_data_syncer` scripts so that
they will stay working after we make changes to the
`canonical-data-syncer` repo.

The plan for those changes is:
1. Rename the existing `canonical-data-syncer` repo to `configlet-v3`.
2. Use that repo to develop `configlet` for Exercism v3. The previous
   functionality will be adapted into a `configlet`-style CLI with a
   `sync` subcommand.
3. When we are ready, rename the existing `configlet` repo to
   `configlet-v2`, and the `configlet-v3` repo to `configlet`.

After step 1, GitHub will redirect `canonical-data-syncer` traffic to
the renamed repo. However, each fetch script was implemented to download
the latest release, and in future the latest release will not be
backwards-compatible with `canonical-data-syncer`: it will instead have
a `configlet`-style CLI with a `sync` subcommand.

Therefore, this commit alters each fetch script so that it downloads the
final release of `canonical-data-syncer`. We hard-code the download by
`id`, rather than by tag, giving us the option to start the
new `configlet` versioning at `v0.1.0`. We must also add the
`--location` flag to the first `curl` command so that it follows
redirects. The request in the `.ps1` script already follows redirects.

In the future, track repos can remove each `fetch-canonical_data_syncer`
script by either:
- adding the upcoming new version of the  `fetch-configlet` script
- or simply waiting until the `sync` functionality is available in the
  repo located at `exercism/configlet`.
