### PR TITLE
🤖 Add file patterns to config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -11,7 +11,6 @@
   "blurb": "Dart is a general purpose programming language which has seen a rise in popularity for its usages in mobile and web application development.",
   "version": 3,
   "online_editor": null,
-  "test_pattern": "_test\\.dart$",
   "files": {
     "solution": [
       "lib/%{snake_slug}.dart"
@@ -20,7 +19,7 @@
       "test/%{snake_slug}_test.dart"
     ],
     "example": [
-      "lib/example.dart"
+      ".meta/lib/example.dart"
     ],
     "exemplar": [
       "path/to/%{kebab_slug}.ext"

--- a/config.json
+++ b/config.json
@@ -22,7 +22,7 @@
       ".meta/lib/example.dart"
     ],
     "exemplar": [
-      "path/to/%{kebab_slug}.ext"
+      ".meta/exemplar.dart"
     ]
   },
   "exercises": {

--- a/config.json
+++ b/config.json
@@ -12,6 +12,20 @@
   "version": 3,
   "online_editor": null,
   "test_pattern": "_test\\.dart$",
+  "files": {
+    "solution": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "test": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "example": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "exemplar": [
+      "path/to/%{kebab_slug}.ext"
+    ]
+  },
   "exercises": {
     "concept": [
       {

--- a/config.json
+++ b/config.json
@@ -14,13 +14,13 @@
   "test_pattern": "_test\\.dart$",
   "files": {
     "solution": [
-      "path/to/%{kebab_slug}.ext"
+      "lib/%{snake_slug}.dart"
     ],
     "test": [
-      "path/to/%{kebab_slug}.ext"
+      "test/%{snake_slug}_test.dart"
     ],
     "example": [
-      "path/to/%{kebab_slug}.ext"
+      "lib/example.dart"
     ],
     "exemplar": [
       "path/to/%{kebab_slug}.ext"


### PR DESCRIPTION
**⚠ This PR requires you to make a simple change before merging. ⚠**

---

To save maintainers from having to manually specify the `files` key in their exercises' `.meta/config.json` files, we are providing support for track-level patterns. See [this PR](https://github.com/exercism/docs/pull/58) for details.

This PR adds (**purposefully wrong**) file patterns to the `config.json` file. It is up to you, the track maintainers, to change these patterns to their correct value.

You can use the following placeholders:
- `%{kebab_slug}`: the `kebab-case` exercise slug (e.g. `bit-manipulation`)
- `%{snake_slug}`: the `snake_case` exercise slug (e.g. `bit_manipulation`)
- `%{camel_slug}`: the `camelCase` exercise slug (e.g. `bitManipulation`)
- `%{pascal_slug}`: the `PascalCase` exercise slug (e.g. `BitManipulation`)

We will soon update `configlet` to enable it to automatically populate the `.meta/config.json` file's `files` property, at which point we will then batch-PR updates to all tracks that have merged this PR.

## Tracking
https://github.com/exercism/v3-launch/issues/19
