### PR TITLE
Migrate to null safety via Dart 2.12.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: ['2.10']
+        tag: ['2.12']
 
     container:
       image:  google/dart:${{ matrix.tag }}

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -7,7 +7,6 @@ import 'package:yaml/yaml.dart';
 
 // Constants
 const _scriptFileName = 'create-exercise';
-const _constSet = <dynamic>{};
 
 final _parser = ArgParser()
   ..addSeparator('Usage: $_scriptFileName [--spec-path path] <slug>')
@@ -193,8 +192,9 @@ String _finalizeReturnType(String expected, String returnType) {
     return 'Map$extracted';
   } else {
     if (expected == 'false' ||
-        expected == 'true' ||
-        expected.contains(RegExp(r'([0-9.]+)')) ||
+        expected == 'true') {
+      return 'bool';
+    } else if (expected.contains(RegExp(r'([0-9.]+)')) ||
         expected.contains(RegExp(r"('[a-zA-Z, \'!]{0,}')"))) {
       return returnType;
     } else {
@@ -293,7 +293,8 @@ bool _containsWhitespaceCodes(String input) {
 String _determineBestReturnType(List<dynamic> specCases) {
   final expectedList = retrieveListOfExpected(specCases);
 
-  final dynamic first = expectedList.isNotEmpty ? expectedList.first : null;
+  final dynamic first = expectedList != null && expectedList.isNotEmpty
+      ? expectedList.first : null;
 
   if (first is Iterable) {
     final iterableType = '${_getIterableType(first)}';
@@ -332,7 +333,12 @@ String _determineBestReturnType(List<dynamic> specCases) {
 }
 
 /// Parses through a list of test cases to assemble a list of all the expected values within the test cases.
-Set<dynamic> retrieveListOfExpected(List<dynamic> testCases, {Set<dynamic> expectedTypeSet = _constSet}) {
+Set<dynamic>? retrieveListOfExpected(List<dynamic> testCases, {Set<dynamic>? expectedTypeSet}) {
+
+  if (expectedTypeSet == null) {
+    expectedTypeSet = <dynamic>{};
+  }
+
   for (var count = 0; count < testCases.length; count++) {
     if (testCases[count] is Map) {
       final entry = testCases[count] as Map;
@@ -348,7 +354,7 @@ Set<dynamic> retrieveListOfExpected(List<dynamic> testCases, {Set<dynamic> expec
         }
 
         if (addEntry) {
-          expectedTypeSet.add(entry['expected']);
+          expectedTypeSet?.add(entry['expected']);
         }
       }
 

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -7,6 +7,7 @@ import 'package:yaml/yaml.dart';
 
 // Constants
 const _scriptFileName = 'create-exercise';
+const _defaultSet = <dynamic>{};
 
 final _parser = ArgParser()
   ..addSeparator('Usage: $_scriptFileName [--spec-path path] <slug>')
@@ -330,11 +331,7 @@ String _determineBestReturnType(List<dynamic> specCases) {
 }
 
 /// Parses through a list of test cases to assemble a list of all the expected values within the test cases.
-Set<dynamic>? retrieveListOfExpected(List<dynamic> testCases, {Set<dynamic>? expectedTypeSet}) {
-  if (expectedTypeSet == null) {
-    expectedTypeSet = <dynamic>{};
-  }
-
+Set<dynamic> retrieveListOfExpected(List<dynamic> testCases, {Set<dynamic> expectedTypeSet = _defaultSet}) {
   for (var count = 0; count < testCases.length; count++) {
     if (testCases[count] is Map) {
       final entry = testCases[count] as Map;
@@ -350,17 +347,19 @@ Set<dynamic>? retrieveListOfExpected(List<dynamic> testCases, {Set<dynamic>? exp
         }
 
         if (addEntry) {
-          expectedTypeSet?.add(entry['expected']);
+          expectedTypeSet = Set<dynamic>.of(expectedTypeSet)..add(entry['expected']);
         }
       }
 
       if (entry.containsKey('cases')) {
-        expectedTypeSet = retrieveListOfExpected(entry['cases'] as List, expectedTypeSet: expectedTypeSet);
+        expectedTypeSet =
+            Set<dynamic>.of(retrieveListOfExpected(entry['cases'] as List, expectedTypeSet: expectedTypeSet));
       }
     }
 
     if (testCases[count] is List) {
-      expectedTypeSet = retrieveListOfExpected(testCases[count] as List, expectedTypeSet: expectedTypeSet);
+      expectedTypeSet =
+          Set<dynamic>.of(retrieveListOfExpected(testCases[count] as List, expectedTypeSet: expectedTypeSet));
     }
   }
 

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -191,11 +191,9 @@ String _finalizeReturnType(String expected, String returnType) {
     final extracted = iterableType.stringMatch(expected);
     return 'Map$extracted';
   } else {
-    if (expected == 'false' ||
-        expected == 'true') {
+    if (expected == 'false' || expected == 'true') {
       return 'bool';
-    } else if (expected.contains(RegExp(r'([0-9.]+)')) ||
-        expected.contains(RegExp(r"('[a-zA-Z, \'!]{0,}')"))) {
+    } else if (expected.contains(RegExp(r'([0-9.]+)')) || expected.contains(RegExp(r"('[a-zA-Z, \'!]{0,}')"))) {
       return returnType;
     } else {
       return expected;
@@ -293,8 +291,7 @@ bool _containsWhitespaceCodes(String input) {
 String _determineBestReturnType(List<dynamic> specCases) {
   final expectedList = retrieveListOfExpected(specCases);
 
-  final dynamic first = expectedList != null && expectedList.isNotEmpty
-      ? expectedList.first : null;
+  final dynamic first = expectedList != null && expectedList.isNotEmpty ? expectedList.first : null;
 
   if (first is Iterable) {
     final iterableType = '${_getIterableType(first)}';
@@ -334,7 +331,6 @@ String _determineBestReturnType(List<dynamic> specCases) {
 
 /// Parses through a list of test cases to assemble a list of all the expected values within the test cases.
 Set<dynamic>? retrieveListOfExpected(List<dynamic> testCases, {Set<dynamic>? expectedTypeSet}) {
-
   if (expectedTypeSet == null) {
     expectedTypeSet = <dynamic>{};
   }

--- a/exercises/concept/.gitignore
+++ b/exercises/concept/.gitignore
@@ -1,1 +1,0 @@
-.dart_tool/

--- a/exercises/concept/futures/.gitignore
+++ b/exercises/concept/futures/.gitignore
@@ -1,2 +1,0 @@
-.dart_tool/
-.packages

--- a/exercises/concept/futures/pubspec.yaml
+++ b/exercises/concept/futures/pubspec.yaml
@@ -1,6 +1,6 @@
-name: futures
+name: 'futures'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   dart_style: '^1.0.8'
   test: '<2.0.0'

--- a/exercises/concept/numbers/.gitignore
+++ b/exercises/concept/numbers/.gitignore
@@ -1,2 +1,0 @@
-.dart_tool/
-.packages

--- a/exercises/concept/numbers/pubspec.yaml
+++ b/exercises/concept/numbers/pubspec.yaml
@@ -1,6 +1,6 @@
-name: numbers
+name: 'numbers'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   dart_style: '^1.0.8'
   test: '<2.0.0'

--- a/exercises/concept/strings/.gitignore
+++ b/exercises/concept/strings/.gitignore
@@ -1,2 +1,0 @@
-.dart_tool/
-.packages

--- a/exercises/concept/strings/pubspec.yaml
+++ b/exercises/concept/strings/pubspec.yaml
@@ -1,6 +1,6 @@
-name: strings
+name: 'strings'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   dart_style: '^1.0.8'
   test: '<2.0.0'

--- a/exercises/practice/acronym/pubspec.yaml
+++ b/exercises/practice/acronym/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'acronym'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/allergies/pubspec.yaml
+++ b/exercises/practice/allergies/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'allergies'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/anagram/.meta/lib/example.dart
+++ b/exercises/practice/anagram/.meta/lib/example.dart
@@ -2,7 +2,7 @@ class Anagram {
   List<String> findAnagrams(String subject, List<String> candidates) {
     Map<String, int> subjectCharsMap = countCharacters(subject);
 
-    List<String> matchTracker = List<String>();
+    List<String> matchTracker = <String>[];
 
     for (String possible in candidates) {
       if (possible.toLowerCase() != subject.toLowerCase()) {
@@ -19,12 +19,12 @@ class Anagram {
   }
 
   Map<String, int> countCharacters(String word) {
-    Map<String, int> charTracker = Map<String, int>();
+    Map<String, int> charTracker = <String, int>{};
 
     for (int counter = 0; counter < word.length; counter++) {
       var key = word[counter].toLowerCase();
 
-      charTracker[key] = charTracker.containsKey(key) ? charTracker[key] + 1 : 1;
+      charTracker[key] = charTracker.containsKey(key) ? charTracker[key]! + 1 : 1;
     }
 
     return charTracker;
@@ -32,7 +32,7 @@ class Anagram {
 }
 
 bool mapsMatch(Map<String, int> subjectCharsMap, Map<String, int> possibleCharMap) {
-  List<bool> trackingMatches = List<bool>();
+  List<bool> trackingMatches = <bool>[];
 
   for (String key in possibleCharMap.keys) {
     if (subjectCharsMap.containsKey(key)) {

--- a/exercises/practice/anagram/pubspec.yaml
+++ b/exercises/practice/anagram/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'anagram'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/armstrong-numbers/pubspec.yaml
+++ b/exercises/practice/armstrong-numbers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'armstrong_numbers'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/beer-song/pubspec.yaml
+++ b/exercises/practice/beer-song/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'beer_song'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/binary-search-tree/.meta/lib/example.dart
+++ b/exercises/practice/binary-search-tree/.meta/lib/example.dart
@@ -4,18 +4,17 @@ class BinarySearchTree<T extends Comparable<T>> {
 
   BinarySearchTree(T rootData) : root = new Node<T>(rootData) {
     // Note: [assert] does not run in release mode
-    assert(rootData != null);
   }
 
   /// Returns an empty `List` if [root] is `null`.
   ///
   /// Otherwise returns data traversed in ascending order.
   Iterable<T> get sortedData sync* {
-    for (var t in root?.ascendingOrder ?? <T>[]) yield t;
+    for (var t in root.ascendingOrder) yield t;
   }
 
   /// Returns `true` on success, `false` on failure.
-  bool insert(T value) => root?.insert(value) ?? false;
+  bool insert(T value) => root.insert(value);
 }
 
 class Node<T extends Comparable<T>> {
@@ -23,20 +22,17 @@ class Node<T extends Comparable<T>> {
   final T data;
 
   /// Left node of this node, can be `null`
-  Node<T> left;
+  Node<T>? left;
 
   /// Right node of this node, can be `null`
-  Node<T> right;
+  Node<T>? right;
 
   Node(this.data, [this.left, this.right]) {
     // Note: [assert] does not run in release mode
-    assert(data != null);
   }
 
   /// This is **inorder** traversal of the tree.
   Iterable<T> get ascendingOrder sync* {
-    if (data == null) return;
-
     /// Traverse left sub-tree if it's present
     for (var t in left?.ascendingOrder ?? <T>[]) yield t;
 
@@ -48,8 +44,6 @@ class Node<T extends Comparable<T>> {
 
   /// Returns `true` on success, `false` on failure.
   bool insert(T value) {
-    if (value == null) return false;
-
     /// Insert in left sub-tree if its a smaller or equal number.
     if (value.compareTo(data) <= 0) {
       return left?.insert(value) ?? (left = new Node(value)).data == value;

--- a/exercises/practice/binary-search-tree/.meta/lib/example.dart
+++ b/exercises/practice/binary-search-tree/.meta/lib/example.dart
@@ -2,9 +2,7 @@ class BinarySearchTree<T extends Comparable<T>> {
   /// Root node for the tree.
   final Node<T> root;
 
-  BinarySearchTree(T rootData) : root = new Node<T>(rootData) {
-    // Note: [assert] does not run in release mode
-  }
+  BinarySearchTree(T rootData) : root = new Node<T>(rootData);
 
   /// Returns an empty `List` if [root] is `null`.
   ///
@@ -27,9 +25,7 @@ class Node<T extends Comparable<T>> {
   /// Right node of this node, can be `null`
   Node<T>? right;
 
-  Node(this.data, [this.left, this.right]) {
-    // Note: [assert] does not run in release mode
-  }
+  Node(this.data, [this.left, this.right]);
 
   /// This is **inorder** traversal of the tree.
   Iterable<T> get ascendingOrder sync* {

--- a/exercises/practice/binary-search-tree/pubspec.yaml
+++ b/exercises/practice/binary-search-tree/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'binary_search_tree'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/binary-search-tree/test/binary_search_tree_test.dart
+++ b/exercises/practice/binary-search-tree/test/binary_search_tree_test.dart
@@ -14,21 +14,21 @@ void main() {
         final bst = BinarySearchTree('4')..insert('2');
 
         expect(bst.root.data, equals('4'));
-        expect(bst.root.left.data, equals('2'));
+        expect(bst.root.left!.data, equals('2'));
       }, skip: true);
 
       test('same number at left node', () {
         final bst = BinarySearchTree('4')..insert('4');
 
         expect(bst.root.data, equals('4'));
-        expect(bst.root.left.data, equals('4'));
+        expect(bst.root.left!.data, equals('4'));
       }, skip: true);
 
       test('greater number at right node', () {
         final bst = BinarySearchTree('4')..insert('5');
 
         expect(bst.root.data, equals('4'));
-        expect(bst.root.right.data, equals('5'));
+        expect(bst.root.right!.data, equals('5'));
       }, skip: true);
 
       test('can create complex tree', () {
@@ -36,13 +36,13 @@ void main() {
 
         expect(bst.root.data, equals('4'));
 
-        expect(bst.root.left.data, equals('2'));
-        expect(bst.root.left.left.data, equals('1'));
-        expect(bst.root.left.right.data, equals('3'));
+        expect(bst.root.left!.data, equals('2'));
+        expect(bst.root.left!.left!.data, equals('1'));
+        expect(bst.root.left!.right!.data, equals('3'));
 
-        expect(bst.root.right.data, equals('6'));
-        expect(bst.root.right.left.data, equals('5'));
-        expect(bst.root.right.right.data, equals('7'));
+        expect(bst.root.right!.data, equals('6'));
+        expect(bst.root.right!.left!.data, equals('5'));
+        expect(bst.root.right!.right!.data, equals('7'));
       }, skip: true);
     });
 

--- a/exercises/practice/bob/pubspec.yaml
+++ b/exercises/practice/bob/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'bob'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/collatz-conjecture/pubspec.yaml
+++ b/exercises/practice/collatz-conjecture/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'collatz_conjecture'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/darts/pubspec.yaml
+++ b/exercises/practice/darts/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'darts'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/diamond/.meta/lib/example.dart
+++ b/exercises/practice/diamond/.meta/lib/example.dart
@@ -5,7 +5,7 @@ class Diamond {
     } else {
       int diamondSize = (letter.codeUnitAt(0) - 64);
       int maxStringSize = diamondSize * 2 - 1;
-      List<String> diamond = new List<String>();
+      List<String> diamond = <String>[];
 
       for (int i = 0; i < diamondSize; i++) {
         String row = "".padRight(maxStringSize, " ");

--- a/exercises/practice/diamond/pubspec.yaml
+++ b/exercises/practice/diamond/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'diamond'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/difference-of-squares/pubspec.yaml
+++ b/exercises/practice/difference-of-squares/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'difference_of_squares'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/gigasecond/lib/gigasecond.dart
+++ b/exercises/practice/gigasecond/lib/gigasecond.dart
@@ -1,3 +1,4 @@
 DateTime add(final DateTime birthDate) {
-  // Put your code here
+  // Replace the throw call and put your code here
+  throw ('Unimplemented method');
 }

--- a/exercises/practice/gigasecond/lib/gigasecond.dart
+++ b/exercises/practice/gigasecond/lib/gigasecond.dart
@@ -1,4 +1,4 @@
 DateTime add(final DateTime birthDate) {
   // Replace the throw call and put your code here
-  throw ('Unimplemented method');
+  throw UnimplementedError();
 }

--- a/exercises/practice/gigasecond/pubspec.yaml
+++ b/exercises/practice/gigasecond/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'gigasecond'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/hamming/pubspec.yaml
+++ b/exercises/practice/hamming/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'hamming'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/hello-world/pubspec.yaml
+++ b/exercises/practice/hello-world/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'hello_world'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/isbn-verifier/pubspec.yaml
+++ b/exercises/practice/isbn-verifier/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'isbn_verifier'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/isogram/pubspec.yaml
+++ b/exercises/practice/isogram/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'isogram'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/leap/pubspec.yaml
+++ b/exercises/practice/leap/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'leap'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/luhn/pubspec.yaml
+++ b/exercises/practice/luhn/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'luhn'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/matching-brackets/pubspec.yaml
+++ b/exercises/practice/matching-brackets/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'matching_brackets'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/minesweeper/.meta/lib/example.dart
+++ b/exercises/practice/minesweeper/.meta/lib/example.dart
@@ -72,7 +72,7 @@ class Minesweeper {
   /// Number of rows in thie minefield
   int get rows => _minefield.length;
 
-  Minesweeper([List<String> minefield]) {
+  Minesweeper(List<String> minefield) {
     if (minefield.isNotEmpty) {
       _minefield.addAll(
         minefield.map(

--- a/exercises/practice/minesweeper/pubspec.yaml
+++ b/exercises/practice/minesweeper/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'minesweeper'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/nth-prime/pubspec.yaml
+++ b/exercises/practice/nth-prime/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'nth_prime'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/pangram/pubspec.yaml
+++ b/exercises/practice/pangram/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'pangram'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/pascals-triangle/.meta/lib/example.dart
+++ b/exercises/practice/pascals-triangle/.meta/lib/example.dart
@@ -1,29 +1,23 @@
 class PascalsTriangle {
   List<List<int>> rows(int rows) {
-    if (rows <= 0) {
-      return [];
-    } else {
-      final triangle = <List<int>>[];
+    /// Row that was last inserted in the triangle.
+    /// This also adds stateful behaviour to the closure passed to List.generate.
+    List<int> triangle = [];
 
-      for (int x = 1; x <= rows; x++) {
-        final nextRow = <int>[];
+    return List.generate(rows, (rowIndex) {
+      triangle = [
+        /// The 1 that always has to be in the first index of a row.
+        1,
 
-        if (triangle.length > 1) {
-          nextRow.add(1);
-          final previousRow = triangle.elementAt(triangle.length - 1);
+        /// Expand on triangle, only if it's length is greater than 1.
+        if (triangle.length > 1)
+          for (int i = 1; i < triangle.length; i++) triangle[i - 1] + triangle[i],
 
-          for (int i = 1; i < previousRow.length; i++) {
-            nextRow.add(previousRow[i - 1] + previousRow[i]);
-          }
-        } else if (triangle.length == 1) {
-          nextRow.add(1);
-        }
-
-        nextRow.add(1);
-        triangle.add(nextRow);
-      }
+        /// Trailing 1, only if this row's length is greater than 1.
+        if (rowIndex > 0) 1,
+      ];
 
       return triangle;
-    }
+    });
   }
 }

--- a/exercises/practice/pascals-triangle/.meta/lib/example.dart
+++ b/exercises/practice/pascals-triangle/.meta/lib/example.dart
@@ -1,23 +1,25 @@
 class PascalsTriangle {
   List<List<int>> rows(int rows) {
-    /// Row that was last inserted in the triangle.
+    /// Row that was last inserted in the nextRow.
     /// This also adds stateful behaviour to the closure passed to List.generate.
-    List<int> triangle = [];
+    List<int> nextRow = [];
 
-    return List.generate(rows, (rowIndex) {
-      triangle = [
+    final triangle = List.generate(rows, (rowIndex) {
+      nextRow = [
         /// The 1 that always has to be in the first index of a row.
         1,
 
         /// Expand on triangle, only if it's length is greater than 1.
-        if (triangle.length > 1)
-          for (int i = 1; i < triangle.length; i++) triangle[i - 1] + triangle[i],
+        if (nextRow.length > 1)
+          for (int i = 1; i < nextRow.length; i++) nextRow[i - 1] + nextRow[i],
 
         /// Trailing 1, only if this row's length is greater than 1.
         if (rowIndex > 0) 1,
       ];
 
-      return triangle;
+      return nextRow;
     });
+
+    return triangle;
   }
 }

--- a/exercises/practice/pascals-triangle/.meta/lib/example.dart
+++ b/exercises/practice/pascals-triangle/.meta/lib/example.dart
@@ -3,18 +3,23 @@ class PascalsTriangle {
     if (rows <= 0) {
       return [];
     } else {
-      List<List<int>> triangle = new List<List<int>>();
+      final triangle = <List<int>>[];
 
       for (int x = 1; x <= rows; x++) {
-        List<int> nextRow = new List<int>(x)
-          ..[0] = 1
-          ..[x - 1] = 1;
+        final nextRow = <int>[];
+
         if (triangle.length > 1) {
-          List<int> previousRow = triangle.elementAt(triangle.length - 1);
+          nextRow.add(1);
+          final previousRow = triangle.elementAt(triangle.length - 1);
+
           for (int i = 1; i < previousRow.length; i++) {
-            nextRow[i] = previousRow[i - 1] + previousRow[i];
+            nextRow.add(previousRow[i - 1] + previousRow[i]);
           }
+        } else if (triangle.length == 1) {
+          nextRow.add(1);
         }
+
+        nextRow.add(1);
         triangle.add(nextRow);
       }
 

--- a/exercises/practice/pascals-triangle/pubspec.yaml
+++ b/exercises/practice/pascals-triangle/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'pascals_triangle'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/phone-number/.meta/lib/example.dart
+++ b/exercises/practice/phone-number/.meta/lib/example.dart
@@ -1,16 +1,16 @@
 class PhoneNumber {
   /// Returns `String` for a valid number, `null` for invalid.
-  String clean(String phoneNumber) {
+  String? clean(String phoneNumber) {
     /// initialize an empty string.
     String onlyDigits = "";
 
     /// find all digits.
     Iterable<Match> findDigits = RegExp(r'\d+').allMatches(phoneNumber);
     findDigits.forEach((match) {
-      onlyDigits += match.group(0);
+      onlyDigits += match.group(0)!;
 
       /// remove all digits **for an edge case**.
-      phoneNumber = phoneNumber.replaceAll(match.group(0), "");
+      phoneNumber = phoneNumber.replaceAll(match.group(0)!, "");
     });
 
     if (phoneNumber.contains(RegExp(r'[a-zA-Z]'))) throw FormatException('letters not permitted');

--- a/exercises/practice/phone-number/pubspec.yaml
+++ b/exercises/practice/phone-number/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'phone_number'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/phone-number/test/phone_number_test.dart
+++ b/exercises/practice/phone-number/test/phone_number_test.dart
@@ -13,17 +13,17 @@ void main() {
 
 void cleanUpTest() {
   test('cleans the number', () {
-    final String result = phoneNumber.clean('(223) 456-7890');
+    final String? result = phoneNumber.clean('(223) 456-7890');
     expect(result, equals('2234567890'));
   }, skip: false);
 
   test('cleans numbers with dots', () {
-    final String result = phoneNumber.clean('223.456.7890');
+    final String? result = phoneNumber.clean('223.456.7890');
     expect(result, equals('2234567890'));
   }, skip: true);
 
   test('cleans numbers with multiple spaces', () {
-    final String result = phoneNumber.clean('223 456   7890   ');
+    final String? result = phoneNumber.clean('223 456   7890   ');
     expect(result, equals('2234567890'));
   }, skip: true);
 }
@@ -40,12 +40,12 @@ void numberLengthTest() {
   }, skip: true);
 
   test('valid when 11 digits and starting with 1', () {
-    final String result = phoneNumber.clean('12234567890');
+    final String? result = phoneNumber.clean('12234567890');
     expect(result, equals('2234567890'));
   }, skip: true);
 
   test('valid when 11 digits and starting with 1 even with punctuation', () {
-    final String result = phoneNumber.clean('+1 (223) 456-7890');
+    final String? result = phoneNumber.clean('+1 (223) 456-7890');
     expect(result, equals('2234567890'));
   }, skip: true);
 

--- a/exercises/practice/prime-factors/pubspec.yaml
+++ b/exercises/practice/prime-factors/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'prime_factors'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/raindrops/pubspec.yaml
+++ b/exercises/practice/raindrops/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'raindrops'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/resistor-color-duo/pubspec.yaml
+++ b/exercises/practice/resistor-color-duo/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'resistor_color_duo'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/resistor-color/pubspec.yaml
+++ b/exercises/practice/resistor-color/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'resistor_color'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/reverse-string/lib/reverse_string.dart
+++ b/exercises/practice/reverse-string/lib/reverse_string.dart
@@ -1,3 +1,4 @@
 String reverse() {
-  // Put your code here
+  // Replace the throw call and put your code here
+  throw ('Unimplemented method');
 }

--- a/exercises/practice/reverse-string/lib/reverse_string.dart
+++ b/exercises/practice/reverse-string/lib/reverse_string.dart
@@ -1,4 +1,4 @@
 String reverse() {
   // Replace the throw call and put your code here
-  throw ('Unimplemented method');
+  throw UnimplementedError();
 }

--- a/exercises/practice/reverse-string/pubspec.yaml
+++ b/exercises/practice/reverse-string/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'reverse_string'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/rna-transcription/pubspec.yaml
+++ b/exercises/practice/rna-transcription/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'rna_transcription'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/robot-simulator/pubspec.yaml
+++ b/exercises/practice/robot-simulator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'robot_simulator'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/robot-simulator/test/robot_simulator_test.dart
+++ b/exercises/practice/robot-simulator/test/robot_simulator_test.dart
@@ -123,7 +123,7 @@ void main() {
   });
 }
 
-void expected(Robot robot, {Position beAt, Orientation faceTo}) {
+void expected(Robot robot, {required Position beAt, required Orientation faceTo}) {
   expect(robot.position, equals(beAt));
   expect(robot.orientation, equals(faceTo));
 }

--- a/exercises/practice/scrabble-score/.meta/lib/example.dart
+++ b/exercises/practice/scrabble-score/.meta/lib/example.dart
@@ -30,8 +30,8 @@ final Map<String, int> _scores = const {
 int score(String word) {
   int val = 0;
   if (word.length > 0) {
-    word.split('').forEach((char) {
-      int score = _scores[char.toLowerCase()];
+    word.split('').forEach((String char) {
+      final score = _scores[char.toLowerCase()];
       val += score ?? 0;
     });
   }

--- a/exercises/practice/scrabble-score/.meta/lib/example.dart
+++ b/exercises/practice/scrabble-score/.meta/lib/example.dart
@@ -30,7 +30,7 @@ final Map<String, int> _scores = const {
 int score(String word) {
   int val = 0;
   if (word.length > 0) {
-    word.split('').forEach((String char) {
+    word.split('').forEach((char) {
       final score = _scores[char.toLowerCase()];
       val += score ?? 0;
     });

--- a/exercises/practice/scrabble-score/pubspec.yaml
+++ b/exercises/practice/scrabble-score/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'scrabble_score'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/secret-handshake/pubspec.yaml
+++ b/exercises/practice/secret-handshake/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'secret_handshake'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/space-age/.meta/lib/example.dart
+++ b/exercises/practice/space-age/.meta/lib/example.dart
@@ -13,14 +13,16 @@ class SpaceAge {
 
   /// Returns age in years on given [planet]
   /// which can be a [String] or a [Planet].
-  num age({required  String planet, required int seconds}) {
+  num age({required dynamic planet, required int seconds}) {
     double age;
-    planet.substring(0);
+    (planet as String).substring(0);
 
-    if (planets.containsKey(planet)) {
-      age = planets[planet]!.ageInYears(seconds);
+    if (planet is String && planets.containsKey(planet)) {
+      String asString = planet;
+
+      age = planets[asString]!.ageInYears(seconds);
     } else if (planet is Planet) {
-      Planet asPlanet = planets[planet]!;
+      Planet asPlanet = planet as Planet;
 
       age = asPlanet.ageInYears(seconds);
     } else {

--- a/exercises/practice/space-age/.meta/lib/example.dart
+++ b/exercises/practice/space-age/.meta/lib/example.dart
@@ -1,6 +1,6 @@
 class SpaceAge {
   /// A Mapping of planet as a `String` to corresponding class
-  Map<String, Planet> planets = {
+  static final Map<String, Planet> planets = {
     'Earth': Earth(),
     'Mercury': Mercury(),
     'Venus': Venus(),
@@ -13,16 +13,14 @@ class SpaceAge {
 
   /// Returns age in years on given [planet]
   /// which can be a [String] or a [Planet].
-  num age({dynamic planet, int seconds}) {
+  num age({required  String planet, required int seconds}) {
     double age;
-    (planet as String).substring(0);
+    planet.substring(0);
 
-    if (planet is String && planets.containsKey(planet)) {
-      String asString = planet;
-
-      age = planets[asString].ageInYears(seconds);
+    if (planets.containsKey(planet)) {
+      age = planets[planet]!.ageInYears(seconds);
     } else if (planet is Planet) {
-      Planet asPlanet = planet;
+      Planet asPlanet = planets[planet]!;
 
       age = asPlanet.ageInYears(seconds);
     } else {

--- a/exercises/practice/space-age/pubspec.yaml
+++ b/exercises/practice/space-age/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'space_age'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/triangle/pubspec.yaml
+++ b/exercises/practice/triangle/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'triangle'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/two-fer/lib/two_fer.dart
+++ b/exercises/practice/two-fer/lib/two_fer.dart
@@ -1,3 +1,4 @@
 String twoFer() {
-  // Put your code here
+  // Replace the throw call and put your code here
+  throw ('Unimplemented method');
 }

--- a/exercises/practice/two-fer/lib/two_fer.dart
+++ b/exercises/practice/two-fer/lib/two_fer.dart
@@ -1,4 +1,4 @@
 String twoFer() {
   // Replace the throw call and put your code here
-  throw ('Unimplemented method');
+  throw UnimplementedError();
 }

--- a/exercises/practice/two-fer/pubspec.yaml
+++ b/exercises/practice/two-fer/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'two_fer'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/word-count/.meta/lib/example.dart
+++ b/exercises/practice/word-count/.meta/lib/example.dart
@@ -1,6 +1,6 @@
 class WordCount {
-  Map<String?, int> countWords(String input) {
-    final count = <String?, int>{};
+  Map<String, int> countWords(String input) {
+    final count = <String, int>{};
 
     /// make a list of all words using regex.
     /// \\w+ matches any number of letters
@@ -8,10 +8,10 @@ class WordCount {
     /// \\w+'\\w  => matches any number of letters then "'" and then a single letter
     ///  e.g. don't
     /// \\d+ matches one or more digits
-    final allWords = <String?>[];
+    final allWords = <String>[];
     var wordMatches = RegExp("\\w+'\\w|\\w+|d+").allMatches(input.toLowerCase());
     for (var match in wordMatches) {
-      allWords.add(match.group(0));
+      allWords.add(match.group(0)!);
     }
 
     /// Lists aka "arrays" have a forEach method that applies a function to

--- a/exercises/practice/word-count/.meta/lib/example.dart
+++ b/exercises/practice/word-count/.meta/lib/example.dart
@@ -1,6 +1,6 @@
 class WordCount {
-  Map<String, int> countWords(String input) {
-    Map<String, int> count = Map();
+  Map<String?, int> countWords(String input) {
+    final count = <String?, int>{};
 
     /// make a list of all words using regex.
     /// \\w+ matches any number of letters
@@ -8,7 +8,7 @@ class WordCount {
     /// \\w+'\\w  => matches any number of letters then "'" and then a single letter
     ///  e.g. don't
     /// \\d+ matches one or more digits
-    List<String> allWords = List();
+    final allWords = <String?>[];
     var wordMatches = RegExp("\\w+'\\w|\\w+|d+").allMatches(input.toLowerCase());
     for (var match in wordMatches) {
       allWords.add(match.group(0));
@@ -20,7 +20,7 @@ class WordCount {
     allWords.forEach((singleWord) => count[singleWord] = 0);
 
     /// count all words and set there counter accordingly
-    allWords.forEach((singleWord) => count[singleWord] = count[singleWord] + 1);
+    allWords.forEach((singleWord) => count[singleWord] = count[singleWord]! + 1);
     return count;
   }
 }

--- a/exercises/practice/word-count/pubspec.yaml
+++ b/exercises/practice/word-count/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'word_count'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/word-count/test/word_count_test.dart
+++ b/exercises/practice/word-count/test/word_count_test.dart
@@ -12,74 +12,74 @@ void main() {
 
 void simpleTests() {
   test('count one word', () {
-    final Map<String?, int> result = wordCount.countWords('word');
+    final Map<String, int> result = wordCount.countWords('word');
     expect(result, equals(<String, int>{'word': 1}));
   }, skip: false);
 
   test('count one of each word', () {
-    final Map<String?, int> result = wordCount.countWords('one of each');
+    final Map<String, int> result = wordCount.countWords('one of each');
     expect(result, equals(<String, int>{'one': 1, 'of': 1, 'each': 1}));
   }, skip: true);
 
   test('multiple occurrences of a word', () {
-    final Map<String?, int> result = wordCount.countWords('one fish two fish red fish blue fish');
+    final Map<String, int> result = wordCount.countWords('one fish two fish red fish blue fish');
     expect(result, equals(<String, int>{'one': 1, 'fish': 4, 'two': 1, 'red': 1, 'blue': 1}));
   }, skip: true);
 }
 
 void ignoreSpecialCharacters() {
   test('handles cramped lists', () {
-    final Map<String?, int> result = wordCount.countWords('one,two,three');
+    final Map<String, int> result = wordCount.countWords('one,two,three');
     expect(result, equals(<String, int>{'one': 1, 'two': 1, 'three': 1}));
   }, skip: true);
 
   test('handles expanded lists', () {
-    final Map<String?, int> result = wordCount.countWords('one,\ntwo,\nthree');
+    final Map<String, int> result = wordCount.countWords('one,\ntwo,\nthree');
     expect(result, equals(<String, int>{'one': 1, 'two': 1, 'three': 1}));
   }, skip: true);
 
   test('ignore punctuation', () {
-    final Map<String?, int> result = wordCount.countWords('car: carpet as java: javascript!!&@\$%^&');
+    final Map<String, int> result = wordCount.countWords('car: carpet as java: javascript!!&@\$%^&');
     expect(result, equals(<String, int>{'car': 1, 'carpet': 1, 'as': 1, 'java': 1, 'javascript': 1}));
   }, skip: true);
 
   test('with quotations', () {
-    final Map<String?, int> result = wordCount.countWords('Joe can\'t tell between \'large\' and large.');
+    final Map<String, int> result = wordCount.countWords('Joe can\'t tell between \'large\' and large.');
     expect(result, equals(<String, int>{'joe': 1, 'can\'t': 1, 'tell': 1, 'between': 1, 'large': 2, 'and': 1}));
   }, skip: true);
 }
 
 void notJustWords() {
   test('include numbers', () {
-    final Map<String?, int> result = wordCount.countWords('testing, 1, 2 testing');
+    final Map<String, int> result = wordCount.countWords('testing, 1, 2 testing');
     expect(result, equals(<String, int>{'testing': 2, '1': 1, '2': 1}));
   }, skip: true);
 }
 
 void edgeCases() {
   test('normalize case', () {
-    final Map<String?, int> result = wordCount.countWords('go Go GO Stop stop');
+    final Map<String, int> result = wordCount.countWords('go Go GO Stop stop');
     expect(result, equals(<String, int>{'go': 3, 'stop': 2}));
   }, skip: true);
 
   test('with apostrophes', () {
-    final Map<String?, int> result = wordCount.countWords('First: don\'t laugh. Then: don\'t cry.');
+    final Map<String, int> result = wordCount.countWords('First: don\'t laugh. Then: don\'t cry.');
     expect(result, equals(<String, int>{'first': 1, 'don\'t': 2, 'laugh': 1, 'then': 1, 'cry': 1}));
   }, skip: true);
 
   test('substrings from the beginning', () {
-    final Map<String?, int> result = wordCount.countWords('Joe can\'t tell between app, apple and a.');
+    final Map<String, int> result = wordCount.countWords('Joe can\'t tell between app, apple and a.');
     expect(result,
         equals(<String, int>{'joe': 1, 'can\'t': 1, 'tell': 1, 'between': 1, 'app': 1, 'apple': 1, 'and': 1, 'a': 1}));
   }, skip: true);
 
   test('multiple spaces not detected as a word', () {
-    final Map<String?, int> result = wordCount.countWords(' multiple   whitespaces');
+    final Map<String, int> result = wordCount.countWords(' multiple   whitespaces');
     expect(result, equals(<String, int>{'multiple': 1, 'whitespaces': 1}));
   }, skip: true);
 
   test('alternating word separators not detected as a word', () {
-    final Map<String?, int> result = wordCount.countWords(',\n,one,\n ,two \n \'three\'');
+    final Map<String, int> result = wordCount.countWords(',\n,one,\n ,two \n \'three\'');
     expect(result, equals(<String, int>{'one': 1, 'two': 1, 'three': 1}));
   }, skip: true);
 }

--- a/exercises/practice/word-count/test/word_count_test.dart
+++ b/exercises/practice/word-count/test/word_count_test.dart
@@ -12,74 +12,74 @@ void main() {
 
 void simpleTests() {
   test('count one word', () {
-    final Map<String, int> result = wordCount.countWords('word');
+    final Map<String?, int> result = wordCount.countWords('word');
     expect(result, equals(<String, int>{'word': 1}));
   }, skip: false);
 
   test('count one of each word', () {
-    final Map<String, int> result = wordCount.countWords('one of each');
+    final Map<String?, int> result = wordCount.countWords('one of each');
     expect(result, equals(<String, int>{'one': 1, 'of': 1, 'each': 1}));
   }, skip: true);
 
   test('multiple occurrences of a word', () {
-    final Map<String, int> result = wordCount.countWords('one fish two fish red fish blue fish');
+    final Map<String?, int> result = wordCount.countWords('one fish two fish red fish blue fish');
     expect(result, equals(<String, int>{'one': 1, 'fish': 4, 'two': 1, 'red': 1, 'blue': 1}));
   }, skip: true);
 }
 
 void ignoreSpecialCharacters() {
   test('handles cramped lists', () {
-    final Map<String, int> result = wordCount.countWords('one,two,three');
+    final Map<String?, int> result = wordCount.countWords('one,two,three');
     expect(result, equals(<String, int>{'one': 1, 'two': 1, 'three': 1}));
   }, skip: true);
 
   test('handles expanded lists', () {
-    final Map<String, int> result = wordCount.countWords('one,\ntwo,\nthree');
+    final Map<String?, int> result = wordCount.countWords('one,\ntwo,\nthree');
     expect(result, equals(<String, int>{'one': 1, 'two': 1, 'three': 1}));
   }, skip: true);
 
   test('ignore punctuation', () {
-    final Map<String, int> result = wordCount.countWords('car: carpet as java: javascript!!&@\$%^&');
+    final Map<String?, int> result = wordCount.countWords('car: carpet as java: javascript!!&@\$%^&');
     expect(result, equals(<String, int>{'car': 1, 'carpet': 1, 'as': 1, 'java': 1, 'javascript': 1}));
   }, skip: true);
 
   test('with quotations', () {
-    final Map<String, int> result = wordCount.countWords('Joe can\'t tell between \'large\' and large.');
+    final Map<String?, int> result = wordCount.countWords('Joe can\'t tell between \'large\' and large.');
     expect(result, equals(<String, int>{'joe': 1, 'can\'t': 1, 'tell': 1, 'between': 1, 'large': 2, 'and': 1}));
   }, skip: true);
 }
 
 void notJustWords() {
   test('include numbers', () {
-    final Map<String, int> result = wordCount.countWords('testing, 1, 2 testing');
+    final Map<String?, int> result = wordCount.countWords('testing, 1, 2 testing');
     expect(result, equals(<String, int>{'testing': 2, '1': 1, '2': 1}));
   }, skip: true);
 }
 
 void edgeCases() {
   test('normalize case', () {
-    final Map<String, int> result = wordCount.countWords('go Go GO Stop stop');
+    final Map<String?, int> result = wordCount.countWords('go Go GO Stop stop');
     expect(result, equals(<String, int>{'go': 3, 'stop': 2}));
   }, skip: true);
 
   test('with apostrophes', () {
-    final Map<String, int> result = wordCount.countWords('First: don\'t laugh. Then: don\'t cry.');
+    final Map<String?, int> result = wordCount.countWords('First: don\'t laugh. Then: don\'t cry.');
     expect(result, equals(<String, int>{'first': 1, 'don\'t': 2, 'laugh': 1, 'then': 1, 'cry': 1}));
   }, skip: true);
 
   test('substrings from the beginning', () {
-    final Map<String, int> result = wordCount.countWords('Joe can\'t tell between app, apple and a.');
+    final Map<String?, int> result = wordCount.countWords('Joe can\'t tell between app, apple and a.');
     expect(result,
         equals(<String, int>{'joe': 1, 'can\'t': 1, 'tell': 1, 'between': 1, 'app': 1, 'apple': 1, 'and': 1, 'a': 1}));
   }, skip: true);
 
   test('multiple spaces not detected as a word', () {
-    final Map<String, int> result = wordCount.countWords(' multiple   whitespaces');
+    final Map<String?, int> result = wordCount.countWords(' multiple   whitespaces');
     expect(result, equals(<String, int>{'multiple': 1, 'whitespaces': 1}));
   }, skip: true);
 
   test('alternating word separators not detected as a word', () {
-    final Map<String, int> result = wordCount.countWords(',\n,one,\n ,two \n \'three\'');
+    final Map<String?, int> result = wordCount.countWords(',\n,one,\n ,two \n \'three\'');
     expect(result, equals(<String, int>{'one': 1, 'two': 1, 'three': 1}));
   }, skip: true);
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -3,11 +3,7 @@ import 'dart:io';
 import 'package:io/io.dart';
 
 class CommonUtils {
-  CommonUtils() {
-    this._manager = ProcessManager();
-  }
-
-  late ProcessManager _manager;
+  final ProcessManager _manager = ProcessManager();
 
   /// Fetches the configlet file if it doesn't exist already, and returns the
   /// exit code.

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -7,7 +7,7 @@ class CommonUtils {
     this._manager = ProcessManager();
   }
 
-  ProcessManager _manager;
+  late ProcessManager _manager;
 
   /// Fetches the configlet file if it doesn't exist already, and returns the
   /// exit code.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,363 +7,335 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "17.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.10"
+    version: "1.1.0"
   args:
     dependency: "direct dev"
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "2.0.0"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0"
+  cli_util:
+    dependency: transitive
+    description:
+      name: cli_util
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.12"
+    version: "1.15.0"
   convert:
     dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.0"
   coverage:
     dependency: transitive
     description:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0"
+    version: "1.0.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
-  csslib:
-    dependency: transitive
-    description:
-      name: csslib
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.16.1"
+    version: "3.0.0"
   dart_style:
     dependency: "direct dev"
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.6"
+    version: "1.3.14"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.1.0"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  html:
-    dependency: transitive
-    description:
-      name: html
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.14.0+3"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.12.1"
+    version: "2.0.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.0"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.4"
+    version: "4.0.0"
   io:
     dependency: "direct dev"
     description:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4"
+    version: "1.0.0"
   js:
     dependency: transitive
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.1+1"
+    version: "0.6.3"
   logging:
     dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.4"
+    version: "1.0.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.6"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0"
   mime:
     dependency: transitive
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.6+3"
-  multi_server_socket:
-    dependency: transitive
-    description:
-      name: multi_server_socket
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.2"
-  node_interop:
-    dependency: transitive
-    description:
-      name: node_interop
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
-  node_io:
-    dependency: transitive
-    description:
-      name: node_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
+    version: "1.0.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.10"
+    version: "2.0.0"
   package_config:
     dependency: transitive
     description:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.11.0"
   pool:
     dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.4"
+    version: "2.0.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.5"
+    version: "1.0.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.8"
+    version: "1.0.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "1.0.0"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.9"
+    version: "0.10.10"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.7"
+    version: "1.16.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.16"
+    version: "0.3.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.7"
+    version: "0.3.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.4"
+    version: "6.1.0+1"
   watcher:
     dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+15"
+    version: "1.0.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "2.0.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.3"
+    version: "1.0.0"
   yaml:
     dependency: "direct dev"
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.1.0"
 sdks:
-  dart: ">=2.7.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: exercism_dart
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 authors:
   - SuperPaintman <SuperPaintmanDeveloper@gmail.com>
   - Stargator <wildbug@linuxmail.org>
@@ -8,8 +8,8 @@ authors:
   - devkabiir
   - jvarness <jake.varness@gmail.com>
 dev_dependencies:
-  args: '^1.0.0'
+  args: '^2.0.0'
   dart_style: '^1.0.8'
-  io: '^0.3.0'
-  test: '>=0.12.24+8 <2.0.0'
-  yaml: '^2.0.0'
+  io: '^1.0.0'
+  test: '^1.16.0'
+  yaml: '^3.0.0'

--- a/test/create_exercise_test.dart
+++ b/test/create_exercise_test.dart
@@ -209,7 +209,7 @@ linter:
 
           expect(testCaseTemplate('armstrong-numbers', testCase), equals('''
     test('${testCase['description']}', () {
-      final null result = armstrongNumbers.${testCase['property']}(${testCase['input']['number']});
+      final bool result = armstrongNumbers.${testCase['property']}(${testCase['input']['number']});
       expect(result, equals(${testCase['expected']}));
     }, skip: false);
 '''));

--- a/test/create_exercise_test.dart
+++ b/test/create_exercise_test.dart
@@ -169,7 +169,7 @@ void main() {
 name: 'foo_bar'
 version: 1.0.0
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'
 '''));


### PR DESCRIPTION
Upgraded the repo to Dart 2.12.1 and migrated each file that needed to be updated.

I opted to go for non-nullable solutions when possible, but few remain nullable.

While this may need students would have to upgrade to Dart 2.12.0, I think that's for the better in the long run.

Given all the work left to migrate to v3 of exercism, I don't think we should maintain nullability. Specifically because the non-nullable syntax (`!`, `?`, `required`, etc) would still require the user upgrades to 2.12.0 in order for that syntax to be readable unless they include the experiment flag for null safety. And we'd have to update the docs for users to know that.

I ran the tests, they all passed. Not sure if the Action will. If that fails, should we include updating it in this PR?