### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "513c85f0-f2aa-483b-b259-285e421ea981",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Dart locally",
+      "blurb": "Learn how to install Dart locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "4e7f0fcb-0001-4a97-8e72-c075ea6646ab",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Dart",
+      "blurb": "An overview of how to get started from scratch with Dart"
+    },
+    {
+      "uuid": "dcb85cff-c5c9-47bd-8a4e-5bdb628ca407",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Dart track",
+      "blurb": "Learn how to test your Dart exercises on Exercism"
+    },
+    {
+      "uuid": "06b56982-4089-4ff0-a3a2-cde7a0ab58a7",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Dart resources",
+      "blurb": "A collection of useful resources to help you master Dart"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
