### PR TITLE
Bump dart style

### DIFF
--- a/exercises/concept/futures/pubspec.yaml
+++ b/exercises/concept/futures/pubspec.yaml
@@ -2,5 +2,4 @@ name: 'futures'
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
-  dart_style: '^1.0.8'
   test: '<2.0.0'

--- a/exercises/concept/numbers/pubspec.yaml
+++ b/exercises/concept/numbers/pubspec.yaml
@@ -2,5 +2,4 @@ name: 'numbers'
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
-  dart_style: '^1.0.8'
   test: '<2.0.0'

--- a/exercises/concept/strings/pubspec.yaml
+++ b/exercises/concept/strings/pubspec.yaml
@@ -2,5 +2,4 @@ name: 'strings'
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
-  dart_style: '^1.0.8'
   test: '<2.0.0'

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.14"
+    version: "2.0.0"
   file:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ authors:
   - jvarness <jake.varness@gmail.com>
 dev_dependencies:
   args: '^2.0.0'
-  dart_style: '^1.0.8'
+  dart_style: '^2.0.0'
   io: '^1.0.0'
   test: '^1.16.0'
   yaml: '^3.0.0'


### PR DESCRIPTION
dart_style was finally updated to depend on 2.12 of Dart. This PR updates our dependency and drops dart_style from the concept exercises since dart_style is only needed in our root pubspec.yaml for linting and CI