### PR TITLE
🤖 Fix invalid UUIDs

### DIFF
--- a/config.json
+++ b/config.json
@@ -267,7 +267,7 @@
       {
         "slug": "isbn-verifier",
         "name": "Isbn Verifier",
-        "uuid": "c52dfe2b-5634-4c0c-8ea2-3ca86e5d9a33",
+        "uuid": "cc0b5fe0-ff63-45b6-8bff-7b62fc5995d8",
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
@@ -335,7 +335,7 @@
       {
         "slug": "resistor-color-duo",
         "name": "Resistor Color Duo",
-        "uuid": "98ae146a-67f9-49ae-9cd6-00882a374248",
+        "uuid": "c05b7dd7-4ba3-44bb-87e8-72b83c6f0e8b",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -347,7 +347,7 @@
       {
         "slug": "beer-song",
         "name": "Beer Song",
-        "uuid": "50c34698-7767-42b3-962f-21c735e49787",
+        "uuid": "2a35fc68-3cb9-4790-a1ce-7d881b213e37",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,


### PR DESCRIPTION
This PR regenerates each UUID on the track that was invalid.

To be valid, each value of a `uuid` key must:
- Be a well-formed version 4 UUID (compliant with RFC 4122) in the
  canonical textual representation [1]
- Not exist elsewhere on the track
- Not exist elsewhere on Exercism

A track can generate a suitable UUID by running `configlet uuid`.

In the future, `configlet lint` will produce an error for an invalid
UUID.

[1] That is, it must match this regular expression:
```
^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
```

## Tracking

https://github.com/exercism/v3-launch/issues/29
