### PR TITLE
Set Stargator as inactive maintainer

### DIFF
--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -13,7 +13,7 @@
     },
     {
       "github_username": "Stargator",
-      "alumnus": false,
+      "alumnus": true,
       "show_on_website": true,
       "name": null,
       "link_text": null,


### PR DESCRIPTION
As previously posted in another issue. I just don't feel like I know what's going on with Exercism or this track.

Part of it is definitely due to the rhythm of my contributions and how some initial plans for v3 have changed since I had started work.

Another part is just the frustration due to my understanding of tracks getting help for developing concepts, but that maintainers would still have a say in how the concept exercises are planned.

I don't support scenario concept exercises. I prefer straight to the point exercises that just show off the features surrounding a concept without the fluff.

And since my understanding of the track and Exercism for v3 has drifted from where I thought it would be, I can't contribute when I don't follow much of what is going on.