### PR TITLE
Update leap_test.dart to avoid skipping the tests

### DIFF
--- a/exercises/practice/leap/test/leap_test.dart
+++ b/exercises/practice/leap/test/leap_test.dart
@@ -13,41 +13,41 @@ void main() {
     test('year divisible by 2, not divisible by 4 in common year', () {
       final bool result = leap.leapYear(1970);
       expect(result, equals(false));
-    }, skip: true);
+    }, skip: false);
 
     test('year divisible by 4, not divisible by 100 in leap year', () {
       final bool result = leap.leapYear(1996);
       expect(result, equals(true));
-    }, skip: true);
+    }, skip: false);
 
     test('year divisible by 4 and 5 is still a leap year', () {
       final bool result = leap.leapYear(1960);
       expect(result, equals(true));
-    }, skip: true);
+    }, skip: false);
 
     test('year divisible by 100, not divisible by 400 in common year', () {
       final bool result = leap.leapYear(2100);
       expect(result, equals(false));
-    }, skip: true);
+    }, skip: false);
 
     test('year divisible by 100 but not by 3 is still not a leap year', () {
       final bool result = leap.leapYear(1900);
       expect(result, equals(false));
-    }, skip: true);
+    }, skip: false);
 
     test('year divisible by 400 in leap year', () {
       final bool result = leap.leapYear(2000);
       expect(result, equals(true));
-    }, skip: true);
+    }, skip: false);
 
     test('year divisible by 400 but not by 125 is still a leap year', () {
       final bool result = leap.leapYear(2400);
       expect(result, equals(true));
-    }, skip: true);
+    }, skip: false);
 
     test('year divisible by 200, not divisible by 400 in common year', () {
       final bool result = leap.leapYear(1800);
       expect(result, equals(false));
-    }, skip: true);
+    }, skip: false);
   });
 }


### PR DESCRIPTION
I was working on the leap exercise locally and set the function to return to `false` by default. When, I run the unit test it passes successfully which is unexpected. Upon checking the test cases, I noticed most of the test cases are set to be skippable.

This PR should fix the issue by setting it back to `false`