### PR TITLE
Disable test runner

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "active": true,
   "status": {
     "concept_exercises": false,
-    "test_runner": true,
+    "test_runner": false,
     "representer": false,
     "analyzer": false
   },


### PR DESCRIPTION
We've had some issues getting the test runner to consistently finish running within the allotted time. Until those issues are fixed, let's disable the test runner.