### PR TITLE
Free Programming Books - Dart

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -2,5 +2,5 @@
  * [Dart Language Overview](https://www.dartlang.org/guides/language/language-tour)
  * [Getting Started](https://www.dartlang.org/tutorials/dart-vm/get-started)
  * [Make a command line app](https://www.dartlang.org/tutorials/dart-vm/cmdline)
- * [Free Programming Books - Dart](https://github.com/EbookFoundation/free-programming-books/blob/master/free-programming-books.md#dart)
+ * [Free Programming Books - Dart](https://github.com/EbookFoundation/free-programming-books/blob/master/books/free-programming-books-langs.md#dart)
  * [Dart Testing Overview](https://www.dartlang.org/guides/testing)


### PR DESCRIPTION
The previous hyperlink was not working for "Free Programming Books - Dart" and the 404 page was showing so I checked that link and replaced it with the correct one.
Now Free Programming Books - Dart will take you to the correct page.