### PR TITLE
Remove remaining links to dartlang.org

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -16,7 +16,7 @@ The primary concepts baked into the making of the language were:
 
 Dart is a very versitile language that can be used in a variety of different ways:
 
- - Dart code can be transpiled into JavaScript for [web development](https://dart.dev/web), typically using [AngularDart](https://github.com/angulardart).
+ - Dart code can be transpiled into JavaScript for [web development](https://dart.dev/web), typically using [AngularDart](https://github.com/angulardart/angular).
  - [Application servers](https://www.dart.dev/dart-vm) can be written using Dart.
  - Cross-platform mobile application development can be achieved through a popular framework called [Flutter](https://flutter.io/).
  - [Google Firebase](https://github.com/firebase/firebase-dart) APIs can be integrated into Dart apps using the libraries written by the Firebase team.

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -16,9 +16,9 @@ The primary concepts baked into the making of the language were:
 
 Dart is a very versitile language that can be used in a variety of different ways:
 
- - Dart code can be transpiled into JavaScript for [web development](https://dart.dev/web), typically using [AngularDart](https://webdev.dartlang.org/angular).
+ - Dart code can be transpiled into JavaScript for [web development](https://dart.dev/web), typically using [AngularDart](https://github.com/angulardart).
  - [Application servers](https://www.dart.dev/dart-vm) can be written using Dart.
  - Cross-platform mobile application development can be achieved through a popular framework called [Flutter](https://flutter.io/).
  - [Google Firebase](https://github.com/firebase/firebase-dart) APIs can be integrated into Dart apps using the libraries written by the Firebase team.
 
-There is a rich ecosystem springing up around Dart because the standard (built-in) libraries can be supplemented by open source libraries found on [Pub](https://pub.dartlang.org).
+There is a rich ecosystem springing up around Dart because the standard (built-in) libraries can be supplemented by open source libraries found on [Pub](https://pub.dev).


### PR DESCRIPTION
The last remaining links to dartlang.org have been removed by linking to
either GitHub or pub.dev.

I have found no other mentions of dartlang.org other than in the `pubspec.lock` which is auto-generated.

This PR fixes #364 