### PR TITLE
fixing broken links and readme tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Exercism Dart Track
 
-![build status](https://github.com/exercism/dart/workflows/actions/badge.svg)](https://github.com/exercism/dart/actions) [![Gitter](https://badges.gitter.im/exercism/dart.svg)](https://gitter.im/exercism/dart?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Test](https://github.com/exercism/dart/actions/workflows/test.yml/badge.svg)](https://github.com/exercism/dart/actions/workflows/test.yml) [![Gitter](https://badges.gitter.im/exercism/dart.svg)](https://gitter.im/exercism/dart?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Exercism exercises in Dart.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -12,7 +12,7 @@
     * Follow the links below for updating your PATH on Windows, Linux and Mac platforms:
         * [Instructions for Windows](https://www.computerhope.com/issues/ch000549.htm)
         * [Instructions for Linux](https://www.computerhope.com/issues/ch001647.htm)
-        * [Instructions for Mac](https://www.pegaxchange.com/tag/macos-sierra-add-entry-to-path-variable/)
+        * [Instructions for Mac](https://support.apple.com/guide/terminal/apd382cc5fa-4f58-4449-b20a-41c53c006f8f/mac)
 
 #### Verify Installation
 * From a new command window or terminal, type `dart --version` to verify that Dart is now available. If the output shows the version number, then Dart is correctly installed on your computer.

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -2,5 +2,5 @@
  * [Dart Language Overview](https://www.dart.dev/guides/language/language-tour)
  * [Getting Started](https://www.dart.dev/tutorials/dart-vm/get-started)
  * [Make a command line app](https://www.dart.dev/tutorials/dart-vm/cmdline)
- * [Free Programming Books - Dart](https://github.com/EbookFoundation/free-programming-books/blob/master/books/free-programming-books-langs.md#dart)
+ * [Free Programming Books - Dart](https://github.com/EbookFoundation/free-programming-books/blob/main/books/free-programming-books-langs.md#dart)
  * [Dart Testing Overview](https://www.dart.dev/guides/testing)

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -4,4 +4,5 @@
  * [Community Information](https://www.dart.dev/community)
  * [Stack Overflow](https://stackoverflow.com/questions/tagged/dart)
  * [Dart Subreddit](https://www.reddit.com/r/dartlang)
- * [Free Programming Books - Dart](https://github.com/EbookFoundation/free-programming-books/blob/master/free-programming-books.md#dart)
+ * [Free Programming Books - Dart](https://github.com/EbookFoundation/free-programming-books/blob/main/books/free-programming-books-langs.md#dart)
+                                   

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -68,7 +68,7 @@ You can also submit your exercise without passing all tests to get feedback.
      ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
-1. Solve the exercise.  Find and work through the `README.md` guide ([view on GitHub](https://github.com/exercism/dart/blob/master/exercises/hello-world/README.md)).
+1. Solve the exercise.  Find and work through the `instructions.md` guide ([view on GitHub](https://github.com/exercism/dart/blob/main/exercises/practice/hello-world/.docs/instructions.md)).
 
 
 Good luck!  Have fun!
@@ -109,7 +109,7 @@ If you get stuck, at any point, don't forget to reach out for [help](https://exe
      ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
-1. Solve the exercise.  Find and work through the `README.md` guide ([view on GitHub](https://github.com/exercism/dart/blob/master/exercises/hello-world/README.md)).
+1. Solve the exercise.  Find and work through the `instructions.md` guide ([view on GitHub](https://github.com/exercism/dart/blob/main/exercises/practice/hello-world/.docs/instructions.md)).
 
 Good luck!  Have fun!
 
@@ -149,7 +149,7 @@ If you get stuck, at any point, don't forget to reach out for [help](https://exe
      ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
-1. Solve the exercise.  Find and work through the `README.md` guide ([view on GitHub](https://github.com/exercism/dart/blob/master/exercises/hello-world/README.md)).
+1. Solve the exercise.  Find and work through the `instructions.md` guide ([view on GitHub](https://github.com/exercism/dart/blob/main/exercises/practice/hello-world/.docs/instructions.md)).
 
 Good luck!  Have fun!
 


### PR DESCRIPTION
The PR is releated to Issue #343 


- Fix Test tag on readme;
- Fix link of repositories who changed the master branch to main;
- Fix broken link to OSX PATH configuration;
- Fix links to hello-world exercise; 