### PR TITLE
Set minimum version to 2.18 for all pubspec.yaml files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: ['2.12']
+        tag: ['2.18']
 
     container:
-      image:  google/dart:${{ matrix.tag }}
+      image:  dart:${{ matrix.tag }}
 
     steps:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/bin/check_formatting.dart
+++ b/bin/check_formatting.dart
@@ -7,7 +7,7 @@ Future main() async {
 
   print('Checking all Dart files formatting...');
   errorCode = await utils
-      .runCmd('pub', ['run', 'dart_style:format', '-i', '0', '-l', '120', '-n', '--set-exit-if-changed', '.']);
+      .runCmd('dart', ['run', 'dart_style:format', '-i', '0', '-l', '120', '-n', '--set-exit-if-changed', '.']);
 
   if (errorCode != 0) {
     print('Checking exercise formatting failed!!');

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -94,7 +94,7 @@ String pubTemplate(String name, String version) => '''
 name: '${snakeCase(name)}'
 version: $version
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'
 ''';

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -252,7 +252,7 @@ void _generateExercise(Map<String, Object> specification, String exerciseFilenam
   }
 
   // The output from file generation is not always well-formatted, use dartfmt to clean it up
-  final fmtSuccess = _runProcess('pub', ['run', 'dart_style:format', '-i', '0', '-l', '120', '-w', exerciseDir.path]);
+  final fmtSuccess = _runProcess('dart', ['run', 'dart_style:format', '-i', '0', '-l', '120', '-w', exerciseDir.path]);
   if (fmtSuccess) {
     stdout.write('Successfully created a rough-draft of tests at \'$testFileName\'.\n');
     stdout.write('You should check this over and fix or refine as necessary.\n');
@@ -261,10 +261,10 @@ void _generateExercise(Map<String, Object> specification, String exerciseFilenam
         .write('Warning: dart_style:format exited with an error, files in \'${exerciseDir.path}\' may be malformed.\n');
   }
 
-  // Install deps
+  // Install dependencies
   Directory.current = exerciseDir;
 
-  final pubSuccess = _runProcess('pub', ['get']);
+  final pubSuccess = _runProcess('dart', ['pub', 'get']);
   assert(pubSuccess);
 }
 

--- a/bin/presubmit.dart
+++ b/bin/presubmit.dart
@@ -11,10 +11,10 @@ Future<Null> main() async {
   }
 
   print('Formatting all Dart files...');
-  await utils.runCmd('pub', ['run', 'dart_style:format', '-l', '120', '-w', '.']);
+  await utils.runCmd('dart', ['run', 'dart_style:format', '-l', '120', '-w', '.']);
 
   print('Running tests...');
-  await utils.runCmd('pub', ['run', 'test']);
+  await utils.runCmd('dart', ['run', 'test']);
 
   await utils.terminate();
   print('Done!');

--- a/exercises/concept/futures/pubspec.yaml
+++ b/exercises/concept/futures/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'futures'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/concept/numbers/pubspec.yaml
+++ b/exercises/concept/numbers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'numbers'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/concept/strings/pubspec.yaml
+++ b/exercises/concept/strings/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'strings'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/acronym/pubspec.yaml
+++ b/exercises/practice/acronym/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'acronym'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/allergies/pubspec.yaml
+++ b/exercises/practice/allergies/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'allergies'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/anagram/pubspec.yaml
+++ b/exercises/practice/anagram/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'anagram'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/armstrong-numbers/pubspec.yaml
+++ b/exercises/practice/armstrong-numbers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'armstrong_numbers'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/beer-song/pubspec.yaml
+++ b/exercises/practice/beer-song/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'beer_song'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/binary-search-tree/pubspec.yaml
+++ b/exercises/practice/binary-search-tree/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'binary_search_tree'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/binary-search-tree/test/binary_search_tree_test.dart
+++ b/exercises/practice/binary-search-tree/test/binary_search_tree_test.dart
@@ -32,7 +32,13 @@ void main() {
       }, skip: true);
 
       test('can create complex tree', () {
-        final bst = BinarySearchTree('4')..insert('2')..insert("6")..insert("1")..insert("3")..insert("5")..insert("7");
+        final bst = BinarySearchTree('4')
+          ..insert('2')
+          ..insert("6")
+          ..insert("1")
+          ..insert("3")
+          ..insert("5")
+          ..insert("7");
 
         expect(bst.root.data, equals('4'));
 
@@ -72,7 +78,12 @@ void main() {
       }, skip: true);
 
       test('can sort complex tree', () {
-        final bst = BinarySearchTree('2')..insert("1")..insert("3")..insert("6")..insert("7")..insert("5");
+        final bst = BinarySearchTree('2')
+          ..insert("1")
+          ..insert("3")
+          ..insert("6")
+          ..insert("7")
+          ..insert("5");
 
         expect(bst.sortedData, equals(['1', '2', '3', '5', '6', '7']));
       }, skip: true);

--- a/exercises/practice/bob/pubspec.yaml
+++ b/exercises/practice/bob/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'bob'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/collatz-conjecture/pubspec.yaml
+++ b/exercises/practice/collatz-conjecture/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'collatz_conjecture'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/darts/pubspec.yaml
+++ b/exercises/practice/darts/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'darts'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/diamond/pubspec.yaml
+++ b/exercises/practice/diamond/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'diamond'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/difference-of-squares/pubspec.yaml
+++ b/exercises/practice/difference-of-squares/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'difference_of_squares'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/forth/pubspec.yaml
+++ b/exercises/practice/forth/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'forth'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/gigasecond/pubspec.yaml
+++ b/exercises/practice/gigasecond/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'gigasecond'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/hamming/pubspec.yaml
+++ b/exercises/practice/hamming/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'hamming'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/hello-world/pubspec.yaml
+++ b/exercises/practice/hello-world/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'hello_world'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/isbn-verifier/pubspec.yaml
+++ b/exercises/practice/isbn-verifier/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'isbn_verifier'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/isogram/pubspec.yaml
+++ b/exercises/practice/isogram/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'isogram'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/leap/pubspec.yaml
+++ b/exercises/practice/leap/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'leap'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/luhn/pubspec.yaml
+++ b/exercises/practice/luhn/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'luhn'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/matching-brackets/pubspec.yaml
+++ b/exercises/practice/matching-brackets/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'matching_brackets'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/minesweeper/pubspec.yaml
+++ b/exercises/practice/minesweeper/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'minesweeper'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/nth-prime/pubspec.yaml
+++ b/exercises/practice/nth-prime/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'nth_prime'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/pangram/pubspec.yaml
+++ b/exercises/practice/pangram/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'pangram'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/pascals-triangle/pubspec.yaml
+++ b/exercises/practice/pascals-triangle/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'pascals_triangle'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/phone-number/pubspec.yaml
+++ b/exercises/practice/phone-number/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'phone_number'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/prime-factors/pubspec.yaml
+++ b/exercises/practice/prime-factors/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'prime_factors'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/raindrops/pubspec.yaml
+++ b/exercises/practice/raindrops/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'raindrops'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/resistor-color-duo/pubspec.yaml
+++ b/exercises/practice/resistor-color-duo/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'resistor_color_duo'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/resistor-color/pubspec.yaml
+++ b/exercises/practice/resistor-color/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'resistor_color'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/reverse-string/pubspec.yaml
+++ b/exercises/practice/reverse-string/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'reverse_string'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/rna-transcription/pubspec.yaml
+++ b/exercises/practice/rna-transcription/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'rna_transcription'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/robot-simulator/pubspec.yaml
+++ b/exercises/practice/robot-simulator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'robot_simulator'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/scrabble-score/pubspec.yaml
+++ b/exercises/practice/scrabble-score/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'scrabble_score'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/secret-handshake/pubspec.yaml
+++ b/exercises/practice/secret-handshake/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'secret_handshake'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/space-age/pubspec.yaml
+++ b/exercises/practice/space-age/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'space_age'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/triangle/pubspec.yaml
+++ b/exercises/practice/triangle/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'triangle'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/two-fer/pubspec.yaml
+++ b/exercises/practice/two-fer/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'two_fer'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/word-count/pubspec.yaml
+++ b/exercises/practice/word-count/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'word_count'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -338,4 +338,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,28 +7,28 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "17.0.0"
+    version: "49.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "5.1.0"
   args:
     dependency: "direct dev"
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.3.1"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -36,195 +36,181 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.0"
-  cli_util:
-    dependency: transitive
-    description:
-      name: cli_util
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.3.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.2"
   coverage:
     dependency: transitive
     description:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.6.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.2"
   dart_style:
     dependency: "direct dev"
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.2.4"
   file:
     dependency: transitive
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.0"
+    version: "6.1.4"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   io:
     dependency: "direct dev"
     description:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.3"
   js:
     dependency: transitive
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   logging:
     dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.12"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.8.0"
   mime:
     dependency: transitive
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.2"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   package_config:
     dependency: transitive
     description:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.11.0"
+    version: "1.8.2"
   pool:
     dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.1"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.1"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.2"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -245,7 +231,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -259,83 +245,83 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.8"
+    version: "1.21.6"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.14"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.19"
+    version: "0.4.18"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.0+1"
+    version: "9.4.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.2.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.2.0"
   yaml:
     dependency: "direct dev"
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
 sdks:
   dart: ">=2.18.0 <3.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,7 +49,7 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.1"
   coverage:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,5 +11,5 @@ dev_dependencies:
   args: '^2.0.0'
   dart_style: '^2.0.0'
   io: '^1.0.0'
-  test: '^1.16.0'
-  yaml: '^3.0.0'
+  test: '>=1.21.6 <2.0.0'
+  yaml: '^3.1.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: exercism_dart
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 authors:
   - SuperPaintman <SuperPaintmanDeveloper@gmail.com>
   - Stargator <wildbug@linuxmail.org>

--- a/test/create_exercise_test.dart
+++ b/test/create_exercise_test.dart
@@ -169,7 +169,7 @@ void main() {
 name: 'foo_bar'
 version: 1.0.0
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 dev_dependencies:
   test: '<2.0.0'
 '''));

--- a/test/exercises_test.dart
+++ b/test/exercises_test.dart
@@ -75,10 +75,10 @@ Running tests for: $packageName
 
     for (List<String> cmds in [
       /// Pull dependencies
-      ['pub', 'upgrade'],
+      ['dart', 'pub', 'upgrade'],
 
       /// Run all exercise tests
-      ['pub', 'run', 'test', '--run-skipped']
+      ['dart', 'test', '--run-skipped']
     ]) {
       await runCmd(cmds);
     }


### PR DESCRIPTION
We last time we did a mass update of the version of Dart used was 2.12. With the release of 2.18, I think it's time for another update.

This does pose a risk of forcing students/users to upgrade to a newer version of Dart, but that's going to happen eventually.