### PR TITLE
Sync metadata for practice exercises

### DIFF
--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -13,7 +13,7 @@
       ".meta/lib/example.dart"
     ]
   },
-  "blurb": "Convert a long phrase to its acronym",
+  "blurb": "Convert a long phrase to its acronym.",
   "source": "Julien Vanier",
   "source_url": "https://github.com/monkbroc"
 }

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -15,5 +15,5 @@
   },
   "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",
   "source": "Learn to Program by Chris Pine",
-  "source_url": "https://pine.fm/LearnToProgram/?Chapter=06"
+  "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"
 }

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -20,5 +20,5 @@
   },
   "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
   "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
-  "source_url": "https://pine.fm/LearnToProgram/?Chapter=06"
+  "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"
 }

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -13,6 +13,6 @@
       ".meta/lib/example.dart"
     ]
   },
-  "blurb": "Write a function that returns the earned points in a single toss of a Darts game",
+  "blurb": "Write a function that returns the earned points in a single toss of a Darts game.",
   "source": "Inspired by an exercise created by a professor Della Paolera in Argentina"
 }

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -17,7 +17,7 @@
       ".meta/lib/example.dart"
     ]
   },
-  "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
+  "blurb": "The classical introductory exercise. Just say \"Hello, World!\".",
   "source": "This is an exercise to introduce users to using Exercism",
-  "source_url": "https://en.wikipedia.org/wiki/%22Hello,_world!%22_program"
+  "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"
 }

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -19,5 +19,5 @@
   },
   "blurb": "Given a year, report if it is a leap year.",
   "source": "JavaRanch Cattle Drive, exercise 3",
-  "source_url": "https://coderanch.com/t/718816/Leap"
+  "source_url": "http://www.javaranch.com/leap.jsp"
 }

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -16,5 +16,5 @@
       ".meta/lib/example.dart"
     ]
   },
-  "blurb": "Add the numbers to a minesweeper board"
+  "blurb": "Add the numbers to a minesweeper board."
 }

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -15,5 +15,5 @@
   },
   "blurb": "Given a number n, determine what the nth prime is.",
   "source": "A variation on Problem 7 at Project Euler",
-  "source_url": "https://projecteuler.net/problem=7"
+  "source_url": "http://projecteuler.net/problem=7"
 }

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -19,5 +19,5 @@
   },
   "blurb": "Compute Pascal's triangle up to a given number of rows.",
   "source": "Pascal's Triangle at Wolfram Math World",
-  "source_url": "https://mathworld.wolfram.com/PascalsTriangle.html"
+  "source_url": "http://mathworld.wolfram.com/PascalsTriangle.html"
 }

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -13,7 +13,7 @@
       ".meta/lib/example.dart"
     ]
   },
-  "blurb": "Convert a resistor band's color to its numeric representation",
+  "blurb": "Convert a resistor band's color to its numeric representation.",
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1458"
 }

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -16,7 +16,7 @@
       ".meta/lib/example.dart"
     ]
   },
-  "blurb": "Reverse a string",
+  "blurb": "Reverse a string.",
   "source": "Introductory challenge to reverse an input string",
   "source_url": "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb"
 }

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -15,5 +15,5 @@
   },
   "blurb": "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.",
   "source": "Bert, in Mary Poppins",
-  "source_url": "https://www.imdb.com/title/tt0058331/quotes/qt0437047"
+  "source_url": "http://www.imdb.com/title/tt0058331/quotes/qt0437047"
 }

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -16,6 +16,6 @@
       ".meta/lib/example.dart"
     ]
   },
-  "blurb": "Create a sentence of the form \"One for X, one for me.\"",
+  "blurb": "Create a sentence of the form \"One for X, one for me.\".",
   "source_url": "https://github.com/exercism/problem-specifications/issues/757"
 }


### PR DESCRIPTION
This runs

    bin/configlet sync --update --metadata --exercise SLUG

on any exercises that don't require any changes to their test suites in order to get up to date with the problem-specifications repository.

I generally prefer to update one exercise at a time, but reviewing gets quite tedious when there are lots of small updates, so I went with a bulk update here.