### PR TITLE
Sync allergies with problem-specifications

### DIFF
--- a/exercises/practice/allergies/.docs/instructions.md
+++ b/exercises/practice/allergies/.docs/instructions.md
@@ -2,20 +2,18 @@
 
 Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.
 
-An allergy test produces a single numeric score which contains the
-information about all the allergies the person has (that they were
-tested for).
+An allergy test produces a single numeric score which contains the information about all the allergies the person has (that they were tested for).
 
 The list of items (and their value) that were tested are:
 
-* eggs (1)
-* peanuts (2)
-* shellfish (4)
-* strawberries (8)
-* tomatoes (16)
-* chocolate (32)
-* pollen (64)
-* cats (128)
+- eggs (1)
+- peanuts (2)
+- shellfish (4)
+- strawberries (8)
+- tomatoes (16)
+- chocolate (32)
+- pollen (64)
+- cats (128)
 
 So if Tom is allergic to peanuts and chocolate, he gets a score of 34.
 
@@ -24,7 +22,6 @@ Now, given just that score of 34, your program should be able to say:
 - Whether Tom is allergic to any one of those allergens listed above.
 - All the allergens Tom is allergic to.
 
-Note: a given score may include allergens **not** listed above (i.e.
-allergens that score 256, 512, 1024, etc.).  Your program should
-ignore those components of the score.  For example, if the allergy
-score is 257, your program should only report the eggs (1) allergy.
+Note: a given score may include allergens **not** listed above (i.e.  allergens that score 256, 512, 1024, etc.).
+Your program should ignore those components of the score.
+For example, if the allergy score is 257, your program should only report the eggs (1) allergy.

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -3,7 +3,8 @@
     "amscotti"
   ],
   "contributors": [
-    "Stargator"
+    "Stargator",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/allergies/.meta/tests.toml
+++ b/exercises/practice/allergies/.meta/tests.toml
@@ -1,150 +1,160 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [17fc7296-2440-4ac4-ad7b-d07c321bc5a0]
-description = "not allergic to anything"
+description = "testing for eggs allergy -> not allergic to anything"
 
 [07ced27b-1da5-4c2e-8ae2-cb2791437546]
-description = "allergic only to eggs"
+description = "testing for eggs allergy -> allergic only to eggs"
 
 [5035b954-b6fa-4b9b-a487-dae69d8c5f96]
-description = "allergic to eggs and something else"
+description = "testing for eggs allergy -> allergic to eggs and something else"
 
 [64a6a83a-5723-4b5b-a896-663307403310]
-description = "allergic to something, but not eggs"
+description = "testing for eggs allergy -> allergic to something, but not eggs"
 
 [90c8f484-456b-41c4-82ba-2d08d93231c6]
-description = "allergic to everything"
+description = "testing for eggs allergy -> allergic to everything"
 
 [d266a59a-fccc-413b-ac53-d57cb1f0db9d]
-description = "not allergic to anything"
+description = "testing for peanuts allergy -> not allergic to anything"
 
 [ea210a98-860d-46b2-a5bf-50d8995b3f2a]
-description = "allergic only to peanuts"
+description = "testing for peanuts allergy -> allergic only to peanuts"
 
 [eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b]
-description = "allergic to peanuts and something else"
+description = "testing for peanuts allergy -> allergic to peanuts and something else"
 
 [9152058c-ce39-4b16-9b1d-283ec6d25085]
-description = "allergic to something, but not peanuts"
+description = "testing for peanuts allergy -> allergic to something, but not peanuts"
 
 [d2d71fd8-63d5-40f9-a627-fbdaf88caeab]
-description = "allergic to everything"
+description = "testing for peanuts allergy -> allergic to everything"
 
 [b948b0a1-cbf7-4b28-a244-73ff56687c80]
-description = "not allergic to anything"
+description = "testing for shellfish allergy -> not allergic to anything"
 
 [9ce9a6f3-53e9-4923-85e0-73019047c567]
-description = "allergic only to shellfish"
+description = "testing for shellfish allergy -> allergic only to shellfish"
 
 [b272fca5-57ba-4b00-bd0c-43a737ab2131]
-description = "allergic to shellfish and something else"
+description = "testing for shellfish allergy -> allergic to shellfish and something else"
 
 [21ef8e17-c227-494e-8e78-470a1c59c3d8]
-description = "allergic to something, but not shellfish"
+description = "testing for shellfish allergy -> allergic to something, but not shellfish"
 
 [cc789c19-2b5e-4c67-b146-625dc8cfa34e]
-description = "allergic to everything"
+description = "testing for shellfish allergy -> allergic to everything"
 
 [651bde0a-2a74-46c4-ab55-02a0906ca2f5]
-description = "not allergic to anything"
+description = "testing for strawberries allergy -> not allergic to anything"
 
 [b649a750-9703-4f5f-b7f7-91da2c160ece]
-description = "allergic only to strawberries"
+description = "testing for strawberries allergy -> allergic only to strawberries"
 
 [50f5f8f3-3bac-47e6-8dba-2d94470a4bc6]
-description = "allergic to strawberries and something else"
+description = "testing for strawberries allergy -> allergic to strawberries and something else"
 
 [23dd6952-88c9-48d7-a7d5-5d0343deb18d]
-description = "allergic to something, but not strawberries"
+description = "testing for strawberries allergy -> allergic to something, but not strawberries"
 
 [74afaae2-13b6-43a2-837a-286cd42e7d7e]
-description = "allergic to everything"
+description = "testing for strawberries allergy -> allergic to everything"
 
 [c49a91ef-6252-415e-907e-a9d26ef61723]
-description = "not allergic to anything"
+description = "testing for tomatoes allergy -> not allergic to anything"
 
 [b69c5131-b7d0-41ad-a32c-e1b2cc632df8]
-description = "allergic only to tomatoes"
+description = "testing for tomatoes allergy -> allergic only to tomatoes"
 
 [1ca50eb1-f042-4ccf-9050-341521b929ec]
-description = "allergic to tomatoes and something else"
+description = "testing for tomatoes allergy -> allergic to tomatoes and something else"
 
 [e9846baa-456b-4eff-8025-034b9f77bd8e]
-description = "allergic to something, but not tomatoes"
+description = "testing for tomatoes allergy -> allergic to something, but not tomatoes"
 
 [b2414f01-f3ad-4965-8391-e65f54dad35f]
-description = "allergic to everything"
+description = "testing for tomatoes allergy -> allergic to everything"
 
 [978467ab-bda4-49f7-b004-1d011ead947c]
-description = "not allergic to anything"
+description = "testing for chocolate allergy -> not allergic to anything"
 
 [59cf4e49-06ea-4139-a2c1-d7aad28f8cbc]
-description = "allergic only to chocolate"
+description = "testing for chocolate allergy -> allergic only to chocolate"
 
 [b0a7c07b-2db7-4f73-a180-565e07040ef1]
-description = "allergic to chocolate and something else"
+description = "testing for chocolate allergy -> allergic to chocolate and something else"
 
 [f5506893-f1ae-482a-b516-7532ba5ca9d2]
-description = "allergic to something, but not chocolate"
+description = "testing for chocolate allergy -> allergic to something, but not chocolate"
 
 [02debb3d-d7e2-4376-a26b-3c974b6595c6]
-description = "allergic to everything"
+description = "testing for chocolate allergy -> allergic to everything"
 
 [17f4a42b-c91e-41b8-8a76-4797886c2d96]
-description = "not allergic to anything"
+description = "testing for pollen allergy -> not allergic to anything"
 
 [7696eba7-1837-4488-882a-14b7b4e3e399]
-description = "allergic only to pollen"
+description = "testing for pollen allergy -> allergic only to pollen"
 
 [9a49aec5-fa1f-405d-889e-4dfc420db2b6]
-description = "allergic to pollen and something else"
+description = "testing for pollen allergy -> allergic to pollen and something else"
 
 [3cb8e79f-d108-4712-b620-aa146b1954a9]
-description = "allergic to something, but not pollen"
+description = "testing for pollen allergy -> allergic to something, but not pollen"
 
 [1dc3fe57-7c68-4043-9d51-5457128744b2]
-description = "allergic to everything"
+description = "testing for pollen allergy -> allergic to everything"
 
 [d3f523d6-3d50-419b-a222-d4dfd62ce314]
-description = "not allergic to anything"
+description = "testing for cats allergy -> not allergic to anything"
 
 [eba541c3-c886-42d3-baef-c048cb7fcd8f]
-description = "allergic only to cats"
+description = "testing for cats allergy -> allergic only to cats"
 
 [ba718376-26e0-40b7-bbbe-060287637ea5]
-description = "allergic to cats and something else"
+description = "testing for cats allergy -> allergic to cats and something else"
 
 [3c6dbf4a-5277-436f-8b88-15a206f2d6c4]
-description = "allergic to something, but not cats"
+description = "testing for cats allergy -> allergic to something, but not cats"
 
 [1faabb05-2b98-4995-9046-d83e4a48a7c1]
-description = "allergic to everything"
+description = "testing for cats allergy -> allergic to everything"
 
 [f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f]
-description = "no allergies"
+description = "list when: -> no allergies"
 
 [9e1a4364-09a6-4d94-990f-541a94a4c1e8]
-description = "just eggs"
+description = "list when: -> just eggs"
 
 [8851c973-805e-4283-9e01-d0c0da0e4695]
-description = "just peanuts"
+description = "list when: -> just peanuts"
 
 [2c8943cb-005e-435f-ae11-3e8fb558ea98]
-description = "just strawberries"
+description = "list when: -> just strawberries"
 
 [6fa95d26-044c-48a9-8a7b-9ee46ec32c5c]
-description = "eggs and peanuts"
+description = "list when: -> eggs and peanuts"
 
 [19890e22-f63f-4c5c-a9fb-fb6eacddfe8e]
-description = "more than eggs but not peanuts"
+description = "list when: -> more than eggs but not peanuts"
 
 [4b68f470-067c-44e4-889f-c9fe28917d2f]
-description = "lots of stuff"
+description = "list when: -> lots of stuff"
 
 [0881b7c5-9efa-4530-91bd-68370d054bc7]
-description = "everything"
+description = "list when: -> everything"
 
 [12ce86de-b347-42a0-ab7c-2e0570f0c65b]
-description = "no allergen score parts"
+description = "list when: -> no allergen score parts"
+
+[93c2df3e-4f55-4fed-8116-7513092819cd]
+description = "list when: -> no allergen score parts without highest valid score"

--- a/exercises/practice/allergies/test/allergies_test.dart
+++ b/exercises/practice/allergies/test/allergies_test.dart
@@ -277,4 +277,9 @@ void listWhen() {
     final List<String> result = allergies.list(509);
     expect(result, equals(<String>['eggs', 'shellfish', 'strawberries', 'tomatoes', 'chocolate', 'pollen', 'cats']));
   }, skip: true);
+
+  test('no allergen score parts without highest valid score', () {
+    final List<String> result = allergies.list(257);
+    expect(result, equals(<String>['eggs']));
+  }, skip: true);
 }

--- a/exercises/practice/allergies/test/allergies_test.dart
+++ b/exercises/practice/allergies/test/allergies_test.dart
@@ -1,275 +1,280 @@
-import 'package:allergies/allergies.dart';
 import 'package:test/test.dart';
+import 'package:allergies/allergies.dart';
 
 final allergies = Allergies();
 
 void main() {
-  group('Allergies', () {
-    group('testing for eggs allergy', () {
-      test('not allergic to anything', () {
-        final bool result = allergies.allergicTo('eggs', 0);
-        expect(result, equals(false));
-      }, skip: false);
+  group("Allergies: testing for eggs allergy - ", testingForEggsAllergy);
+  group("Allergies: testing for peanuts allergy - ", testingForPeanutsAllergy);
+  group("Allergies: testing for shellfish allergy - ", testingForShellfishAllergy);
+  group("Allergies: testing for strawberries allergy - ", testingForStrawberriesAllergy);
+  group("Allergies: testing for tomatoes allergy - ", testingForTomatoesAllergy);
+  group("Allergies: testing for chocolate allergy - ", testingForChocolateAllergy);
+  group("Allergies: testing for pollen allergy - ", testingForPollenAllergy);
+  group("Allergies: testing for cats allergy - ", testingForCatsAllergy);
+  group("Allergies: list when: - ", listWhen);
+}
 
-      test('allergic only to eggs', () {
-        final bool result = allergies.allergicTo('eggs', 1);
-        expect(result, equals(true));
-      }, skip: true);
+void testingForEggsAllergy() {
+  test('not allergic to anything', () {
+    final bool result = allergies.allergicTo('eggs', 0);
+    expect(result, equals(false));
+  }, skip: false);
 
-      test('allergic to eggs and something else', () {
-        final bool result = allergies.allergicTo('eggs', 3);
-        expect(result, equals(true));
-      }, skip: true);
+  test('allergic only to eggs', () {
+    final bool result = allergies.allergicTo('eggs', 1);
+    expect(result, equals(true));
+  }, skip: true);
 
-      test('allergic to something, but not eggs', () {
-        final bool result = allergies.allergicTo('eggs', 2);
-        expect(result, equals(false));
-      }, skip: true);
+  test('allergic to eggs and something else', () {
+    final bool result = allergies.allergicTo('eggs', 3);
+    expect(result, equals(true));
+  }, skip: true);
 
-      test('allergic to everything', () {
-        final bool result = allergies.allergicTo('eggs', 255);
-        expect(result, equals(true));
-      }, skip: true);
-    });
+  test('allergic to something, but not eggs', () {
+    final bool result = allergies.allergicTo('eggs', 2);
+    expect(result, equals(false));
+  }, skip: true);
 
-    group('testing for peanuts allergy', () {
-      test('not allergic to anything', () {
-        final bool result = allergies.allergicTo('peanuts', 0);
-        expect(result, equals(false));
-      }, skip: true);
+  test('allergic to everything', () {
+    final bool result = allergies.allergicTo('eggs', 255);
+    expect(result, equals(true));
+  }, skip: true);
+}
 
-      test('allergic only to peanuts', () {
-        final bool result = allergies.allergicTo('peanuts', 2);
-        expect(result, equals(true));
-      }, skip: true);
+void testingForPeanutsAllergy() {
+  test('not allergic to anything', () {
+    final bool result = allergies.allergicTo('peanuts', 0);
+    expect(result, equals(false));
+  }, skip: true);
 
-      test('allergic to peanuts and something else', () {
-        final bool result = allergies.allergicTo('peanuts', 7);
-        expect(result, equals(true));
-      }, skip: true);
+  test('allergic only to peanuts', () {
+    final bool result = allergies.allergicTo('peanuts', 2);
+    expect(result, equals(true));
+  }, skip: true);
 
-      test('allergic to something, but not peanuts', () {
-        final bool result = allergies.allergicTo('peanuts', 5);
-        expect(result, equals(false));
-      }, skip: true);
+  test('allergic to peanuts and something else', () {
+    final bool result = allergies.allergicTo('peanuts', 7);
+    expect(result, equals(true));
+  }, skip: true);
 
-      test('allergic to everything', () {
-        final bool result = allergies.allergicTo('peanuts', 255);
-        expect(result, equals(true));
-      }, skip: true);
-    });
+  test('allergic to something, but not peanuts', () {
+    final bool result = allergies.allergicTo('peanuts', 5);
+    expect(result, equals(false));
+  }, skip: true);
 
-    group('testing for shellfish allergy', () {
-      test('not allergic to anything', () {
-        final bool result = allergies.allergicTo('shellfish', 0);
-        expect(result, equals(false));
-      }, skip: true);
+  test('allergic to everything', () {
+    final bool result = allergies.allergicTo('peanuts', 255);
+    expect(result, equals(true));
+  }, skip: true);
+}
 
-      test('allergic only to shellfish', () {
-        final bool result = allergies.allergicTo('shellfish', 4);
-        expect(result, equals(true));
-      }, skip: true);
+void testingForShellfishAllergy() {
+  test('not allergic to anything', () {
+    final bool result = allergies.allergicTo('shellfish', 0);
+    expect(result, equals(false));
+  }, skip: true);
 
-      test('allergic to shellfish and something else', () {
-        final bool result = allergies.allergicTo('shellfish', 14);
-        expect(result, equals(true));
-      }, skip: true);
+  test('allergic only to shellfish', () {
+    final bool result = allergies.allergicTo('shellfish', 4);
+    expect(result, equals(true));
+  }, skip: true);
 
-      test('allergic to something, but not shellfish', () {
-        final bool result = allergies.allergicTo('shellfish', 10);
-        expect(result, equals(false));
-      }, skip: true);
+  test('allergic to shellfish and something else', () {
+    final bool result = allergies.allergicTo('shellfish', 14);
+    expect(result, equals(true));
+  }, skip: true);
 
-      test('allergic to everything', () {
-        final bool result = allergies.allergicTo('shellfish', 255);
-        expect(result, equals(true));
-      }, skip: true);
-    });
+  test('allergic to something, but not shellfish', () {
+    final bool result = allergies.allergicTo('shellfish', 10);
+    expect(result, equals(false));
+  }, skip: true);
 
-    group('testing for strawberries allergy', () {
-      test('not allergic to anything', () {
-        final bool result = allergies.allergicTo('strawberries', 0);
-        expect(result, equals(false));
-      }, skip: true);
+  test('allergic to everything', () {
+    final bool result = allergies.allergicTo('shellfish', 255);
+    expect(result, equals(true));
+  }, skip: true);
+}
 
-      test('allergic only to strawberries', () {
-        final bool result = allergies.allergicTo('strawberries', 8);
-        expect(result, equals(true));
-      }, skip: true);
+void testingForStrawberriesAllergy() {
+  test('not allergic to anything', () {
+    final bool result = allergies.allergicTo('strawberries', 0);
+    expect(result, equals(false));
+  }, skip: true);
 
-      test('allergic to strawberries and something else', () {
-        final bool result = allergies.allergicTo('strawberries', 28);
-        expect(result, equals(true));
-      }, skip: true);
+  test('allergic only to strawberries', () {
+    final bool result = allergies.allergicTo('strawberries', 8);
+    expect(result, equals(true));
+  }, skip: true);
 
-      test('allergic to something, but not strawberries', () {
-        final bool result = allergies.allergicTo('strawberries', 20);
-        expect(result, equals(false));
-      }, skip: true);
+  test('allergic to strawberries and something else', () {
+    final bool result = allergies.allergicTo('strawberries', 28);
+    expect(result, equals(true));
+  }, skip: true);
 
-      test('allergic to everything', () {
-        final bool result = allergies.allergicTo('strawberries', 255);
-        expect(result, equals(true));
-      }, skip: true);
-    });
+  test('allergic to something, but not strawberries', () {
+    final bool result = allergies.allergicTo('strawberries', 20);
+    expect(result, equals(false));
+  }, skip: true);
 
-    group('testing for tomatoes allergy', () {
-      test('not allergic to anything', () {
-        final bool result = allergies.allergicTo('tomatoes', 0);
-        expect(result, equals(false));
-      }, skip: true);
+  test('allergic to everything', () {
+    final bool result = allergies.allergicTo('strawberries', 255);
+    expect(result, equals(true));
+  }, skip: true);
+}
 
-      test('allergic only to tomatoes', () {
-        final bool result = allergies.allergicTo('tomatoes', 16);
-        expect(result, equals(true));
-      }, skip: true);
+void testingForTomatoesAllergy() {
+  test('not allergic to anything', () {
+    final bool result = allergies.allergicTo('tomatoes', 0);
+    expect(result, equals(false));
+  }, skip: true);
 
-      test('allergic to tomatoes and something else', () {
-        final bool result = allergies.allergicTo('tomatoes', 56);
-        expect(result, equals(true));
-      }, skip: true);
+  test('allergic only to tomatoes', () {
+    final bool result = allergies.allergicTo('tomatoes', 16);
+    expect(result, equals(true));
+  }, skip: true);
 
-      test('allergic to something, but not tomatoes', () {
-        final bool result = allergies.allergicTo('tomatoes', 40);
-        expect(result, equals(false));
-      }, skip: true);
+  test('allergic to tomatoes and something else', () {
+    final bool result = allergies.allergicTo('tomatoes', 56);
+    expect(result, equals(true));
+  }, skip: true);
 
-      test('allergic to everything', () {
-        final bool result = allergies.allergicTo('tomatoes', 255);
-        expect(result, equals(true));
-      }, skip: true);
-    });
+  test('allergic to something, but not tomatoes', () {
+    final bool result = allergies.allergicTo('tomatoes', 40);
+    expect(result, equals(false));
+  }, skip: true);
 
-    group('testing for chocolate allergy', () {
-      test('not allergic to anything', () {
-        final bool result = allergies.allergicTo('chocolate', 0);
-        expect(result, equals(false));
-      }, skip: true);
+  test('allergic to everything', () {
+    final bool result = allergies.allergicTo('tomatoes', 255);
+    expect(result, equals(true));
+  }, skip: true);
+}
 
-      test('allergic only to chocolate', () {
-        final bool result = allergies.allergicTo('chocolate', 32);
-        expect(result, equals(true));
-      }, skip: true);
+void testingForChocolateAllergy() {
+  test('not allergic to anything', () {
+    final bool result = allergies.allergicTo('chocolate', 0);
+    expect(result, equals(false));
+  }, skip: true);
 
-      test('allergic to chocolate and something else', () {
-        final bool result = allergies.allergicTo('chocolate', 112);
-        expect(result, equals(true));
-      }, skip: true);
+  test('allergic only to chocolate', () {
+    final bool result = allergies.allergicTo('chocolate', 32);
+    expect(result, equals(true));
+  }, skip: true);
 
-      test('allergic to something, but not chocolate', () {
-        final bool result = allergies.allergicTo('chocolate', 80);
-        expect(result, equals(false));
-      }, skip: true);
+  test('allergic to chocolate and something else', () {
+    final bool result = allergies.allergicTo('chocolate', 112);
+    expect(result, equals(true));
+  }, skip: true);
 
-      test('allergic to everything', () {
-        final bool result = allergies.allergicTo('chocolate', 255);
-        expect(result, equals(true));
-      }, skip: true);
-    });
+  test('allergic to something, but not chocolate', () {
+    final bool result = allergies.allergicTo('chocolate', 80);
+    expect(result, equals(false));
+  }, skip: true);
 
-    group('testing for pollen allergy', () {
-      test('not allergic to anything', () {
-        final bool result = allergies.allergicTo('pollen', 0);
-        expect(result, equals(false));
-      }, skip: true);
+  test('allergic to everything', () {
+    final bool result = allergies.allergicTo('chocolate', 255);
+    expect(result, equals(true));
+  }, skip: true);
+}
 
-      test('allergic only to pollen', () {
-        final bool result = allergies.allergicTo('pollen', 64);
-        expect(result, equals(true));
-      }, skip: true);
+void testingForPollenAllergy() {
+  test('not allergic to anything', () {
+    final bool result = allergies.allergicTo('pollen', 0);
+    expect(result, equals(false));
+  }, skip: true);
 
-      test('allergic to pollen and something else', () {
-        final bool result = allergies.allergicTo('pollen', 224);
-        expect(result, equals(true));
-      }, skip: true);
+  test('allergic only to pollen', () {
+    final bool result = allergies.allergicTo('pollen', 64);
+    expect(result, equals(true));
+  }, skip: true);
 
-      test('allergic to something, but not pollen', () {
-        final bool result = allergies.allergicTo('pollen', 160);
-        expect(result, equals(false));
-      }, skip: true);
+  test('allergic to pollen and something else', () {
+    final bool result = allergies.allergicTo('pollen', 224);
+    expect(result, equals(true));
+  }, skip: true);
 
-      test('allergic to everything', () {
-        final bool result = allergies.allergicTo('pollen', 255);
-        expect(result, equals(true));
-      }, skip: true);
-    });
+  test('allergic to something, but not pollen', () {
+    final bool result = allergies.allergicTo('pollen', 160);
+    expect(result, equals(false));
+  }, skip: true);
 
-    group('testing for cats allergy', () {
-      test('not allergic to anything', () {
-        final bool result = allergies.allergicTo('cats', 0);
-        expect(result, equals(false));
-      }, skip: true);
+  test('allergic to everything', () {
+    final bool result = allergies.allergicTo('pollen', 255);
+    expect(result, equals(true));
+  }, skip: true);
+}
 
-      test('allergic only to cats', () {
-        final bool result = allergies.allergicTo('cats', 128);
-        expect(result, equals(true));
-      }, skip: true);
+void testingForCatsAllergy() {
+  test('not allergic to anything', () {
+    final bool result = allergies.allergicTo('cats', 0);
+    expect(result, equals(false));
+  }, skip: true);
 
-      test('allergic to cats and something else', () {
-        final bool result = allergies.allergicTo('cats', 192);
-        expect(result, equals(true));
-      }, skip: true);
+  test('allergic only to cats', () {
+    final bool result = allergies.allergicTo('cats', 128);
+    expect(result, equals(true));
+  }, skip: true);
 
-      test('allergic to something, but not cats', () {
-        final bool result = allergies.allergicTo('cats', 64);
-        expect(result, equals(false));
-      }, skip: true);
+  test('allergic to cats and something else', () {
+    final bool result = allergies.allergicTo('cats', 192);
+    expect(result, equals(true));
+  }, skip: true);
 
-      test('allergic to everything', () {
-        final bool result = allergies.allergicTo('cats', 255);
-        expect(result, equals(true));
-      }, skip: true);
-    });
+  test('allergic to something, but not cats', () {
+    final bool result = allergies.allergicTo('cats', 64);
+    expect(result, equals(false));
+  }, skip: true);
 
-    group('list when:', () {
-      test('no allergies', () {
-        final List<String> result = allergies.list(0);
-        expect(result, equals(<String>[]));
-      }, skip: true);
+  test('allergic to everything', () {
+    final bool result = allergies.allergicTo('cats', 255);
+    expect(result, equals(true));
+  }, skip: true);
+}
 
-      test('just eggs', () {
-        final List<String> result = allergies.list(1);
-        expect(result, equals(<String>['eggs']));
-      }, skip: true);
+void listWhen() {
+  test('no allergies', () {
+    final List<String> result = allergies.list(0);
+    expect(result, equals(<String>[]));
+  }, skip: true);
 
-      test('just peanuts', () {
-        final List<String> result = allergies.list(2);
-        expect(result, equals(<String>['peanuts']));
-      }, skip: true);
+  test('just eggs', () {
+    final List<String> result = allergies.list(1);
+    expect(result, equals(<String>['eggs']));
+  }, skip: true);
 
-      test('just strawberries', () {
-        final List<String> result = allergies.list(8);
-        expect(result, equals(<String>['strawberries']));
-      }, skip: true);
+  test('just peanuts', () {
+    final List<String> result = allergies.list(2);
+    expect(result, equals(<String>['peanuts']));
+  }, skip: true);
 
-      test('eggs and peanuts', () {
-        final List<String> result = allergies.list(3);
-        expect(result, equals(<String>['eggs', 'peanuts']));
-      }, skip: true);
+  test('just strawberries', () {
+    final List<String> result = allergies.list(8);
+    expect(result, equals(<String>['strawberries']));
+  }, skip: true);
 
-      test('more than eggs but not peanuts', () {
-        final List<String> result = allergies.list(5);
-        expect(result, equals(<String>['eggs', 'shellfish']));
-      }, skip: true);
+  test('eggs and peanuts', () {
+    final List<String> result = allergies.list(3);
+    expect(result, equals(<String>['eggs', 'peanuts']));
+  }, skip: true);
 
-      test('lots of stuff', () {
-        final List<String> result = allergies.list(248);
-        expect(result, equals(<String>['strawberries', 'tomatoes', 'chocolate', 'pollen', 'cats']));
-      }, skip: true);
+  test('more than eggs but not peanuts', () {
+    final List<String> result = allergies.list(5);
+    expect(result, equals(<String>['eggs', 'shellfish']));
+  }, skip: true);
 
-      test('everything', () {
-        final List<String> result = allergies.list(255);
-        expect(
-            result,
-            equals(
-                <String>['eggs', 'peanuts', 'shellfish', 'strawberries', 'tomatoes', 'chocolate', 'pollen', 'cats']));
-      }, skip: true);
+  test('lots of stuff', () {
+    final List<String> result = allergies.list(248);
+    expect(result, equals(<String>['strawberries', 'tomatoes', 'chocolate', 'pollen', 'cats']));
+  }, skip: true);
 
-      test('no allergen score parts', () {
-        final List<String> result = allergies.list(509);
-        expect(
-            result, equals(<String>['eggs', 'shellfish', 'strawberries', 'tomatoes', 'chocolate', 'pollen', 'cats']));
-      }, skip: true);
-    });
-  });
+  test('everything', () {
+    final List<String> result = allergies.list(255);
+    expect(result,
+        equals(<String>['eggs', 'peanuts', 'shellfish', 'strawberries', 'tomatoes', 'chocolate', 'pollen', 'cats']));
+  }, skip: true);
+
+  test('no allergen score parts', () {
+    final List<String> result = allergies.list(509);
+    expect(result, equals(<String>['eggs', 'shellfish', 'strawberries', 'tomatoes', 'chocolate', 'pollen', 'cats']));
+  }, skip: true);
 }


### PR DESCRIPTION
This puts all the tests in the same group rather than
grouping them per the canonical-data.json structure in
problem-specifications.

In order to help make the logical groupings apparent,
the test names have been updated to be prefixed with the
group description.

To make it as easy as possible to review, I've indented
the tests two spaces extra in the first commit, and then
fixed the indentation in the second commit.

In the third commit I've synced the allergies exercise by running 

```
bin/configlet sync --update --exercise allergies
```

This brought in updated instructions and an extra test.