### PR TITLE
Sync metadata with problem-specifications

### DIFF
--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -18,6 +18,6 @@
     ]
   },
   "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",
-  "source": "Jumpstart Lab Warm-up",
-  "source_url": "http://jumpstartlab.com"
+  "source": "Exercise by the JumpstartLab team for students at The Turing School of Software and Design.",
+  "source_url": "https://turing.edu"
 }

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -15,5 +15,5 @@
   },
   "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",
   "source": "Learn to Program by Chris Pine",
-  "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"
+  "source_url": "https://pine.fm/LearnToProgram/?Chapter=06"
 }

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -20,5 +20,5 @@
   },
   "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
   "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
-  "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"
+  "source_url": "https://pine.fm/LearnToProgram/?Chapter=06"
 }

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -19,5 +19,5 @@
   },
   "blurb": "Given a letter, print a diamond starting with 'A' with the supplied letter at the widest point.",
   "source": "Seb Rose",
-  "source_url": "http://claysnow.co.uk/recycling-tests-in-tdd/"
+  "source_url": "https://web.archive.org/web/20220807163751/http://claysnow.co.uk/recycling-tests-in-tdd/"
 }

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -18,5 +18,5 @@
   },
   "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
   "source": "Problem 6 at Project Euler",
-  "source_url": "http://projecteuler.net/problem=6"
+  "source_url": "https://projecteuler.net/problem=6"
 }

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -19,5 +19,5 @@
   },
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\".",
   "source": "This is an exercise to introduce users to using Exercism",
-  "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"
+  "source_url": "https://en.wikipedia.org/wiki/%22Hello,_world!%22_program"
 }

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -18,6 +18,6 @@
     ]
   },
   "blurb": "Given a year, report if it is a leap year.",
-  "source": "JavaRanch Cattle Drive, exercise 3",
-  "source_url": "http://www.javaranch.com/leap.jsp"
+  "source": "CodeRanch Cattle Drive, Assignment 3",
+  "source_url": "https://coderanch.com/t/718816/Leap"
 }

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -15,5 +15,5 @@
   },
   "blurb": "Given a number n, determine what the nth prime is.",
   "source": "A variation on Problem 7 at Project Euler",
-  "source_url": "http://projecteuler.net/problem=7"
+  "source_url": "https://projecteuler.net/problem=7"
 }

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -19,5 +19,5 @@
   },
   "blurb": "Compute Pascal's triangle up to a given number of rows.",
   "source": "Pascal's Triangle at Wolfram Math World",
-  "source_url": "http://mathworld.wolfram.com/PascalsTriangle.html"
+  "source_url": "https://www.wolframalpha.com/input/?i=Pascal%27s+triangle"
 }

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -18,5 +18,5 @@
   },
   "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
   "source": "Hyperphysics",
-  "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"
+  "source_url": "https://web.archive.org/web/20220408112140/http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"
 }

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -15,5 +15,5 @@
   },
   "blurb": "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.",
   "source": "Bert, in Mary Poppins",
-  "source_url": "http://www.imdb.com/title/tt0058331/quotes/qt0437047"
+  "source_url": "https://www.imdb.com/title/tt0058331/quotes/qt0437047"
 }

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -18,5 +18,5 @@
   },
   "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",
-  "source_url": "http://pine.fm/LearnToProgram/?Chapter=01"
+  "source_url": "https://pine.fm/LearnToProgram/?Chapter=01"
 }


### PR DESCRIPTION
This syncs metadata for those exercises that do not have
pending changes to the tests.

This brings in updated URLs to ensure that they use
https rather than http.
