### PR TITLE
Sync collatz-conjecture with problem specifications

### DIFF
--- a/exercises/practice/collatz-conjecture/.docs/instructions.md
+++ b/exercises/practice/collatz-conjecture/.docs/instructions.md
@@ -2,10 +2,11 @@
 
 The Collatz Conjecture or 3x+1 problem can be summarized as follows:
 
-Take any positive integer n. If n is even, divide n by 2 to get n / 2. If n is
-odd, multiply n by 3 and add 1 to get 3n + 1. Repeat the process indefinitely.
-The conjecture states that no matter which number you start with, you will
-always reach 1 eventually.
+Take any positive integer n.
+If n is even, divide n by 2 to get n / 2.
+If n is odd, multiply n by 3 and add 1 to get 3n + 1.
+Repeat the process indefinitely.
+The conjecture states that no matter which number you start with, you will always reach 1 eventually.
 
 Given a number n, return the number of steps required to reach 1.
 
@@ -24,4 +25,5 @@ Starting with n = 12, the steps would be as follows:
 8. 2
 9. 1
 
-Resulting in 9 steps. So for input n = 12, the return value would be 9.
+Resulting in 9 steps.
+So for input n = 12, the return value would be 9.

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -2,6 +2,9 @@
   "authors": [
     "amscotti"
   ],
+  "contributors": [
+    "kytrinyx"
+  ],
   "files": {
     "solution": [
       "lib/collatz_conjecture.dart"
@@ -13,7 +16,7 @@
       ".meta/lib/example.dart"
     ]
   },
-  "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
+  "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture.",
   "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",
   "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem"
 }

--- a/exercises/practice/collatz-conjecture/.meta/lib/example.dart
+++ b/exercises/practice/collatz-conjecture/.meta/lib/example.dart
@@ -1,7 +1,7 @@
 class CollatzConjecture {
   int steps(int input) {
     if (input < 1) {
-      throw new ArgumentError('Only positive numbers are allowed');
+      throw new ArgumentError('Only positive integers are allowed');
     }
 
     int n = input;

--- a/exercises/practice/collatz-conjecture/.meta/tests.toml
+++ b/exercises/practice/collatz-conjecture/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [540a3d51-e7a6-47a5-92a3-4ad1838f0bfd]
 description = "zero steps for one"
@@ -16,6 +23,16 @@ description = "large number of even and odd steps"
 
 [7d4750e6-def9-4b86-aec7-9f7eb44f95a3]
 description = "zero is an error"
+include = false
+
+[2187673d-77d6-4543-975e-66df6c50e2da]
+description = "zero is an error"
+reimplements = "7d4750e6-def9-4b86-aec7-9f7eb44f95a3"
 
 [c6c795bf-a288-45e9-86a1-841359ad426d]
 description = "negative value is an error"
+include = false
+
+[ec11f479-56bc-47fd-a434-bcd7a31a7a2e]
+description = "negative value is an error"
+reimplements = "c6c795bf-a288-45e9-86a1-841359ad426d"

--- a/exercises/practice/collatz-conjecture/test/collatz_conjecture_test.dart
+++ b/exercises/practice/collatz-conjecture/test/collatz_conjecture_test.dart
@@ -9,8 +9,8 @@ void main() {
   /// but you can find out more info at https://pub.dev/documentation/test/latest/
   /// if you wish to learn more about predicates and matchers used in Unit Testing for Dart.
   final onlyPositive = predicate(
-      (ArgumentError e) => e is ArgumentError && e.message == 'Only positive numbers are allowed',
-      'an ArgumentError with the message "Only positive numbers are allowed"');
+      (ArgumentError e) => e is ArgumentError && e.message == 'Only positive integers are allowed',
+      'an ArgumentError with the message "Only positive integers are allowed"');
 
   group('CollatzConjecture', () {
     test('zero steps for one', () {

--- a/exercises/practice/collatz-conjecture/test/collatz_conjecture_test.dart
+++ b/exercises/practice/collatz-conjecture/test/collatz_conjecture_test.dart
@@ -1,13 +1,13 @@
 import 'package:collatz_conjecture/collatz_conjecture.dart';
 import 'package:test/test.dart';
 
-/// We are using a predicate to better match the error message from collatzConjecture.
-/// Knowing about predicates are not needed for completing this exercise,
-/// but you can find out more info at https://pub.dev/documentation/test/latest/
-/// if you wish to learn more about predicates and matchers used in Unit Testing for Dart.
-
 void main() {
   final collatzConjecture = new CollatzConjecture();
+
+  /// We are using a predicate to better match the error message from collatzConjecture.
+  /// Knowing about predicates are not needed for completing this exercise,
+  /// but you can find out more info at https://pub.dev/documentation/test/latest/
+  /// if you wish to learn more about predicates and matchers used in Unit Testing for Dart.
   final onlyPositive = predicate(
       (ArgumentError e) => e is ArgumentError && e.message == 'Only positive numbers are allowed',
       'an ArgumentError with the message "Only positive numbers are allowed"');


### PR DESCRIPTION
This regenerate collatz-conjecture, and then syncs with problem-specifications.

The sync brought in updated instructions and
reimplemented test cases. The test cases changed the
expected error message from 'number' to 'integer' which
is more correct for the collatz-conjecture (which does
not apply to floats).

This means that existing solutions will fail the tests,
but with a failure that is trivial to fix.