### PR TITLE
 Sync resistor-color-duo with problem-specifications

### DIFF
--- a/exercises/practice/resistor-color-duo/.docs/instructions.md
+++ b/exercises/practice/resistor-color-duo/.docs/instructions.md
@@ -3,8 +3,8 @@
 If you want to build something using a Raspberry Pi, you'll probably use _resistors_.
 For this exercise, you need to know two things about them:
 
-* Each resistor has a resistance value.
-* Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+- Each resistor has a resistance value.
+- Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
 
 To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
 Each band has a position and a numeric value.
@@ -31,4 +31,3 @@ The band colors are encoded as follows:
 From the example above:
 brown-green should return 15
 brown-green-violet should return 15 too, ignoring the third color.
-

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -3,7 +3,8 @@
     "amscotti"
   ],
   "contributors": [
-    "Stargator"
+    "Stargator",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/resistor-color-duo/.meta/tests.toml
+++ b/exercises/practice/resistor-color-duo/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [ce11995a-5b93-4950-a5e9-93423693b2fc]
 description = "Brown and black"
@@ -11,8 +18,14 @@ description = "Blue and grey"
 [f1886361-fdfd-4693-acf8-46726fe24e0c]
 description = "Yellow and violet"
 
+[b7a6cbd2-ae3c-470a-93eb-56670b305640]
+description = "White and red"
+
 [77a8293d-2a83-4016-b1af-991acc12b9fe]
 description = "Orange and orange"
 
 [0c4fb44f-db7c-4d03-afa8-054350f156a8]
 description = "Ignore additional colors"
+
+[4a8ceec5-0ab4-4904-88a4-daf953a5e818]
+description = "Black and brown, one-digit"

--- a/exercises/practice/resistor-color-duo/test/resistor_color_duo_test.dart
+++ b/exercises/practice/resistor-color-duo/test/resistor_color_duo_test.dart
@@ -20,6 +20,11 @@ void main() {
       expect(result, equals(47));
     }, skip: true);
 
+    test('White and red', () {
+      final result = resistorColorDuo.value(<String>['white', 'red']);
+      expect(result, equals(92));
+    }, skip: true);
+
     test('Orange and orange', () {
       final result = resistorColorDuo.value(<String>['orange', 'orange']);
       expect(result, equals(33));
@@ -28,6 +33,11 @@ void main() {
     test('Ignore additional colors', () {
       final result = resistorColorDuo.value(<String>['green', 'brown', 'orange']);
       expect(result, equals(51));
+    }, skip: true);
+
+    test('Black and brown, one-digit', () {
+      final result = resistorColorDuo.value(<String>['black', 'brown']);
+      expect(result, equals(1));
     }, skip: true);
   });
 }

--- a/exercises/practice/resistor-color-duo/test/resistor_color_duo_test.dart
+++ b/exercises/practice/resistor-color-duo/test/resistor_color_duo_test.dart
@@ -1,32 +1,32 @@
 import 'package:resistor_color_duo/resistor_color_duo.dart';
 import 'package:test/test.dart';
 
-final resistorColorDuo = ResistorColorDuo();
-
 void main() {
+  final resistorColorDuo = ResistorColorDuo();
+
   group('ResistorColorDuo', () {
     test('Brown and black', () {
-      final int result = resistorColorDuo.value(<String>['brown', 'black']);
+      final result = resistorColorDuo.value(<String>['brown', 'black']);
       expect(result, equals(10));
     }, skip: false);
 
     test('Blue and grey', () {
-      final int result = resistorColorDuo.value(<String>['blue', 'grey']);
+      final result = resistorColorDuo.value(<String>['blue', 'grey']);
       expect(result, equals(68));
     }, skip: true);
 
     test('Yellow and violet', () {
-      final int result = resistorColorDuo.value(<String>['yellow', 'violet']);
+      final result = resistorColorDuo.value(<String>['yellow', 'violet']);
       expect(result, equals(47));
     }, skip: true);
 
     test('Orange and orange', () {
-      final int result = resistorColorDuo.value(<String>['orange', 'orange']);
+      final result = resistorColorDuo.value(<String>['orange', 'orange']);
       expect(result, equals(33));
     }, skip: true);
 
     test('Ignore additional colors', () {
-      final int result = resistorColorDuo.value(<String>['green', 'brown', 'orange']);
+      final result = resistorColorDuo.value(<String>['green', 'brown', 'orange']);
       expect(result, equals(51));
     }, skip: true);
   });


### PR DESCRIPTION
- Regenerate resistor-color-duo in first commit to minimize diff when syncing
- Sync resistor-color-duo with problem-specifications

This brings in improved documentation and a couple of new tests.
It also removes the explicit type when assigning 'result' in the tests.