### PR TITLE
Remove explicit type definitions

### DIFF
--- a/exercises/practice/allergies/test/allergies_test.dart
+++ b/exercises/practice/allergies/test/allergies_test.dart
@@ -17,269 +17,269 @@ void main() {
 
 void testingForEggsAllergy() {
   test('not allergic to anything', () {
-    final bool result = allergies.allergicTo('eggs', 0);
+    final result = allergies.allergicTo('eggs', 0);
     expect(result, equals(false));
   }, skip: false);
 
   test('allergic only to eggs', () {
-    final bool result = allergies.allergicTo('eggs', 1);
+    final result = allergies.allergicTo('eggs', 1);
     expect(result, equals(true));
   }, skip: true);
 
   test('allergic to eggs and something else', () {
-    final bool result = allergies.allergicTo('eggs', 3);
+    final result = allergies.allergicTo('eggs', 3);
     expect(result, equals(true));
   }, skip: true);
 
   test('allergic to something, but not eggs', () {
-    final bool result = allergies.allergicTo('eggs', 2);
+    final result = allergies.allergicTo('eggs', 2);
     expect(result, equals(false));
   }, skip: true);
 
   test('allergic to everything', () {
-    final bool result = allergies.allergicTo('eggs', 255);
+    final result = allergies.allergicTo('eggs', 255);
     expect(result, equals(true));
   }, skip: true);
 }
 
 void testingForPeanutsAllergy() {
   test('not allergic to anything', () {
-    final bool result = allergies.allergicTo('peanuts', 0);
+    final result = allergies.allergicTo('peanuts', 0);
     expect(result, equals(false));
   }, skip: true);
 
   test('allergic only to peanuts', () {
-    final bool result = allergies.allergicTo('peanuts', 2);
+    final result = allergies.allergicTo('peanuts', 2);
     expect(result, equals(true));
   }, skip: true);
 
   test('allergic to peanuts and something else', () {
-    final bool result = allergies.allergicTo('peanuts', 7);
+    final result = allergies.allergicTo('peanuts', 7);
     expect(result, equals(true));
   }, skip: true);
 
   test('allergic to something, but not peanuts', () {
-    final bool result = allergies.allergicTo('peanuts', 5);
+    final result = allergies.allergicTo('peanuts', 5);
     expect(result, equals(false));
   }, skip: true);
 
   test('allergic to everything', () {
-    final bool result = allergies.allergicTo('peanuts', 255);
+    final result = allergies.allergicTo('peanuts', 255);
     expect(result, equals(true));
   }, skip: true);
 }
 
 void testingForShellfishAllergy() {
   test('not allergic to anything', () {
-    final bool result = allergies.allergicTo('shellfish', 0);
+    final result = allergies.allergicTo('shellfish', 0);
     expect(result, equals(false));
   }, skip: true);
 
   test('allergic only to shellfish', () {
-    final bool result = allergies.allergicTo('shellfish', 4);
+    final result = allergies.allergicTo('shellfish', 4);
     expect(result, equals(true));
   }, skip: true);
 
   test('allergic to shellfish and something else', () {
-    final bool result = allergies.allergicTo('shellfish', 14);
+    final result = allergies.allergicTo('shellfish', 14);
     expect(result, equals(true));
   }, skip: true);
 
   test('allergic to something, but not shellfish', () {
-    final bool result = allergies.allergicTo('shellfish', 10);
+    final result = allergies.allergicTo('shellfish', 10);
     expect(result, equals(false));
   }, skip: true);
 
   test('allergic to everything', () {
-    final bool result = allergies.allergicTo('shellfish', 255);
+    final result = allergies.allergicTo('shellfish', 255);
     expect(result, equals(true));
   }, skip: true);
 }
 
 void testingForStrawberriesAllergy() {
   test('not allergic to anything', () {
-    final bool result = allergies.allergicTo('strawberries', 0);
+    final result = allergies.allergicTo('strawberries', 0);
     expect(result, equals(false));
   }, skip: true);
 
   test('allergic only to strawberries', () {
-    final bool result = allergies.allergicTo('strawberries', 8);
+    final result = allergies.allergicTo('strawberries', 8);
     expect(result, equals(true));
   }, skip: true);
 
   test('allergic to strawberries and something else', () {
-    final bool result = allergies.allergicTo('strawberries', 28);
+    final result = allergies.allergicTo('strawberries', 28);
     expect(result, equals(true));
   }, skip: true);
 
   test('allergic to something, but not strawberries', () {
-    final bool result = allergies.allergicTo('strawberries', 20);
+    final result = allergies.allergicTo('strawberries', 20);
     expect(result, equals(false));
   }, skip: true);
 
   test('allergic to everything', () {
-    final bool result = allergies.allergicTo('strawberries', 255);
+    final result = allergies.allergicTo('strawberries', 255);
     expect(result, equals(true));
   }, skip: true);
 }
 
 void testingForTomatoesAllergy() {
   test('not allergic to anything', () {
-    final bool result = allergies.allergicTo('tomatoes', 0);
+    final result = allergies.allergicTo('tomatoes', 0);
     expect(result, equals(false));
   }, skip: true);
 
   test('allergic only to tomatoes', () {
-    final bool result = allergies.allergicTo('tomatoes', 16);
+    final result = allergies.allergicTo('tomatoes', 16);
     expect(result, equals(true));
   }, skip: true);
 
   test('allergic to tomatoes and something else', () {
-    final bool result = allergies.allergicTo('tomatoes', 56);
+    final result = allergies.allergicTo('tomatoes', 56);
     expect(result, equals(true));
   }, skip: true);
 
   test('allergic to something, but not tomatoes', () {
-    final bool result = allergies.allergicTo('tomatoes', 40);
+    final result = allergies.allergicTo('tomatoes', 40);
     expect(result, equals(false));
   }, skip: true);
 
   test('allergic to everything', () {
-    final bool result = allergies.allergicTo('tomatoes', 255);
+    final result = allergies.allergicTo('tomatoes', 255);
     expect(result, equals(true));
   }, skip: true);
 }
 
 void testingForChocolateAllergy() {
   test('not allergic to anything', () {
-    final bool result = allergies.allergicTo('chocolate', 0);
+    final result = allergies.allergicTo('chocolate', 0);
     expect(result, equals(false));
   }, skip: true);
 
   test('allergic only to chocolate', () {
-    final bool result = allergies.allergicTo('chocolate', 32);
+    final result = allergies.allergicTo('chocolate', 32);
     expect(result, equals(true));
   }, skip: true);
 
   test('allergic to chocolate and something else', () {
-    final bool result = allergies.allergicTo('chocolate', 112);
+    final result = allergies.allergicTo('chocolate', 112);
     expect(result, equals(true));
   }, skip: true);
 
   test('allergic to something, but not chocolate', () {
-    final bool result = allergies.allergicTo('chocolate', 80);
+    final result = allergies.allergicTo('chocolate', 80);
     expect(result, equals(false));
   }, skip: true);
 
   test('allergic to everything', () {
-    final bool result = allergies.allergicTo('chocolate', 255);
+    final result = allergies.allergicTo('chocolate', 255);
     expect(result, equals(true));
   }, skip: true);
 }
 
 void testingForPollenAllergy() {
   test('not allergic to anything', () {
-    final bool result = allergies.allergicTo('pollen', 0);
+    final result = allergies.allergicTo('pollen', 0);
     expect(result, equals(false));
   }, skip: true);
 
   test('allergic only to pollen', () {
-    final bool result = allergies.allergicTo('pollen', 64);
+    final result = allergies.allergicTo('pollen', 64);
     expect(result, equals(true));
   }, skip: true);
 
   test('allergic to pollen and something else', () {
-    final bool result = allergies.allergicTo('pollen', 224);
+    final result = allergies.allergicTo('pollen', 224);
     expect(result, equals(true));
   }, skip: true);
 
   test('allergic to something, but not pollen', () {
-    final bool result = allergies.allergicTo('pollen', 160);
+    final result = allergies.allergicTo('pollen', 160);
     expect(result, equals(false));
   }, skip: true);
 
   test('allergic to everything', () {
-    final bool result = allergies.allergicTo('pollen', 255);
+    final result = allergies.allergicTo('pollen', 255);
     expect(result, equals(true));
   }, skip: true);
 }
 
 void testingForCatsAllergy() {
   test('not allergic to anything', () {
-    final bool result = allergies.allergicTo('cats', 0);
+    final result = allergies.allergicTo('cats', 0);
     expect(result, equals(false));
   }, skip: true);
 
   test('allergic only to cats', () {
-    final bool result = allergies.allergicTo('cats', 128);
+    final result = allergies.allergicTo('cats', 128);
     expect(result, equals(true));
   }, skip: true);
 
   test('allergic to cats and something else', () {
-    final bool result = allergies.allergicTo('cats', 192);
+    final result = allergies.allergicTo('cats', 192);
     expect(result, equals(true));
   }, skip: true);
 
   test('allergic to something, but not cats', () {
-    final bool result = allergies.allergicTo('cats', 64);
+    final result = allergies.allergicTo('cats', 64);
     expect(result, equals(false));
   }, skip: true);
 
   test('allergic to everything', () {
-    final bool result = allergies.allergicTo('cats', 255);
+    final result = allergies.allergicTo('cats', 255);
     expect(result, equals(true));
   }, skip: true);
 }
 
 void listWhen() {
   test('no allergies', () {
-    final List<String> result = allergies.list(0);
+    final result = allergies.list(0);
     expect(result, equals(<String>[]));
   }, skip: true);
 
   test('just eggs', () {
-    final List<String> result = allergies.list(1);
+    final result = allergies.list(1);
     expect(result, equals(<String>['eggs']));
   }, skip: true);
 
   test('just peanuts', () {
-    final List<String> result = allergies.list(2);
+    final result = allergies.list(2);
     expect(result, equals(<String>['peanuts']));
   }, skip: true);
 
   test('just strawberries', () {
-    final List<String> result = allergies.list(8);
+    final result = allergies.list(8);
     expect(result, equals(<String>['strawberries']));
   }, skip: true);
 
   test('eggs and peanuts', () {
-    final List<String> result = allergies.list(3);
+    final result = allergies.list(3);
     expect(result, equals(<String>['eggs', 'peanuts']));
   }, skip: true);
 
   test('more than eggs but not peanuts', () {
-    final List<String> result = allergies.list(5);
+    final result = allergies.list(5);
     expect(result, equals(<String>['eggs', 'shellfish']));
   }, skip: true);
 
   test('lots of stuff', () {
-    final List<String> result = allergies.list(248);
+    final result = allergies.list(248);
     expect(result, equals(<String>['strawberries', 'tomatoes', 'chocolate', 'pollen', 'cats']));
   }, skip: true);
 
   test('everything', () {
-    final List<String> result = allergies.list(255);
+    final result = allergies.list(255);
     expect(result,
         equals(<String>['eggs', 'peanuts', 'shellfish', 'strawberries', 'tomatoes', 'chocolate', 'pollen', 'cats']));
   }, skip: true);
 
   test('no allergen score parts', () {
-    final List<String> result = allergies.list(509);
+    final result = allergies.list(509);
     expect(result, equals(<String>['eggs', 'shellfish', 'strawberries', 'tomatoes', 'chocolate', 'pollen', 'cats']));
   }, skip: true);
 
   test('no allergen score parts without highest valid score', () {
-    final List<String> result = allergies.list(257);
+    final result = allergies.list(257);
     expect(result, equals(<String>['eggs']));
   }, skip: true);
 }

--- a/exercises/practice/anagram/test/anagram_test.dart
+++ b/exercises/practice/anagram/test/anagram_test.dart
@@ -6,83 +6,83 @@ final anagram = Anagram();
 void main() {
   group('Anagram', () {
     test('no matches', () {
-      final List<String> result = anagram.findAnagrams('diaper', <String>['hello', 'world', 'zombies', 'pants']);
+      final result = anagram.findAnagrams('diaper', <String>['hello', 'world', 'zombies', 'pants']);
       expect(result, equals(<String>[]));
     }, skip: false);
 
     test('detects two anagrams', () {
-      final List<String> result = anagram.findAnagrams('solemn', <String>['lemons', 'cherry', 'melons']);
+      final result = anagram.findAnagrams('solemn', <String>['lemons', 'cherry', 'melons']);
       expect(result, equals(<String>['lemons', 'melons']));
     }, skip: true);
 
     test('does not detect anagram subsets', () {
-      final List<String> result = anagram.findAnagrams('good', <String>['dog', 'goody']);
+      final result = anagram.findAnagrams('good', <String>['dog', 'goody']);
       expect(result, equals(<String>[]));
     }, skip: true);
 
     test('detects anagram', () {
-      final List<String> result = anagram.findAnagrams('listen', <String>['enlists', 'google', 'inlets', 'banana']);
+      final result = anagram.findAnagrams('listen', <String>['enlists', 'google', 'inlets', 'banana']);
       expect(result, equals(<String>['inlets']));
     }, skip: true);
 
     test('detects three anagrams', () {
-      final List<String> result =
+      final result =
           anagram.findAnagrams('allergy', <String>['gallery', 'ballerina', 'regally', 'clergy', 'largely', 'leading']);
       expect(result, equals(<String>['gallery', 'regally', 'largely']));
     }, skip: true);
 
     test('detects multiple anagrams with different case', () {
-      final List<String> result = anagram.findAnagrams('nose', <String>['Eons', 'ONES']);
+      final result = anagram.findAnagrams('nose', <String>['Eons', 'ONES']);
       expect(result, equals(<String>['Eons', 'ONES']));
     }, skip: true);
 
     test('does not detect non-anagrams with identical checksum', () {
-      final List<String> result = anagram.findAnagrams('mass', <String>['last']);
+      final result = anagram.findAnagrams('mass', <String>['last']);
       expect(result, equals(<String>[]));
     }, skip: true);
 
     test('detects anagrams case-insensitively', () {
-      final List<String> result = anagram.findAnagrams('Orchestra', <String>['cashregister', 'Carthorse', 'radishes']);
+      final result = anagram.findAnagrams('Orchestra', <String>['cashregister', 'Carthorse', 'radishes']);
       expect(result, equals(<String>['Carthorse']));
     }, skip: true);
 
     test('detects anagrams using case-insensitive subject', () {
-      final List<String> result = anagram.findAnagrams('Orchestra', <String>['cashregister', 'carthorse', 'radishes']);
+      final result = anagram.findAnagrams('Orchestra', <String>['cashregister', 'carthorse', 'radishes']);
       expect(result, equals(<String>['carthorse']));
     }, skip: true);
 
     test('detects anagrams using case-insensitive possible matches', () {
-      final List<String> result = anagram.findAnagrams('orchestra', <String>['cashregister', 'Carthorse', 'radishes']);
+      final result = anagram.findAnagrams('orchestra', <String>['cashregister', 'Carthorse', 'radishes']);
       expect(result, equals(<String>['Carthorse']));
     }, skip: true);
 
     test('does not detect an anagram if the original word is repeated', () {
-      final List<String> result = anagram.findAnagrams('go', <String>['go Go GO']);
+      final result = anagram.findAnagrams('go', <String>['go Go GO']);
       expect(result, equals(<String>[]));
     }, skip: true);
 
     test('anagrams must use all letters exactly once', () {
-      final List<String> result = anagram.findAnagrams('tapper', <String>['patter']);
+      final result = anagram.findAnagrams('tapper', <String>['patter']);
       expect(result, equals(<String>[]));
     }, skip: true);
 
     test('words are not anagrams of themselves', () {
-      final List<String> result = anagram.findAnagrams('BANANA', <String>['BANANA']);
+      final result = anagram.findAnagrams('BANANA', <String>['BANANA']);
       expect(result, equals(<String>[]));
     }, skip: true);
 
     test('words are not anagrams of themselves even if letter case is partially different', () {
-      final List<String> result = anagram.findAnagrams('BANANA', <String>['Banana']);
+      final result = anagram.findAnagrams('BANANA', <String>['Banana']);
       expect(result, equals(<String>[]));
     }, skip: true);
 
     test('words are not anagrams of themselves even if letter case is completely different', () {
-      final List<String> result = anagram.findAnagrams('BANANA', <String>['banana']);
+      final result = anagram.findAnagrams('BANANA', <String>['banana']);
       expect(result, equals(<String>[]));
     }, skip: true);
 
     test('words other than themselves can be anagrams', () {
-      final List<String> result = anagram.findAnagrams('LISTEN', <String>['LISTEN', 'Silent']);
+      final result = anagram.findAnagrams('LISTEN', <String>['LISTEN', 'Silent']);
       expect(result, equals(<String>['Silent']));
     }, skip: true);
   });

--- a/exercises/practice/collatz-conjecture/test/collatz_conjecture_test.dart
+++ b/exercises/practice/collatz-conjecture/test/collatz_conjecture_test.dart
@@ -14,22 +14,22 @@ void main() {
 
   group('CollatzConjecture', () {
     test('zero steps for one', () {
-      final int result = collatzConjecture.steps(1);
+      final result = collatzConjecture.steps(1);
       expect(result, equals(0));
     }, skip: false);
 
     test('divide if even', () {
-      final int result = collatzConjecture.steps(16);
+      final result = collatzConjecture.steps(16);
       expect(result, equals(4));
     }, skip: true);
 
     test('even and odd steps', () {
-      final int result = collatzConjecture.steps(12);
+      final result = collatzConjecture.steps(12);
       expect(result, equals(9));
     }, skip: true);
 
     test('large number of even and odd steps', () {
-      final int result = collatzConjecture.steps(1000000);
+      final result = collatzConjecture.steps(1000000);
       expect(result, equals(152));
     }, skip: true);
 

--- a/exercises/practice/collatz-conjecture/test/collatz_conjecture_test.dart
+++ b/exercises/practice/collatz-conjecture/test/collatz_conjecture_test.dart
@@ -2,7 +2,7 @@ import 'package:collatz_conjecture/collatz_conjecture.dart';
 import 'package:test/test.dart';
 
 void main() {
-  final collatzConjecture = new CollatzConjecture();
+  final collatzConjecture = CollatzConjecture();
 
   /// We are using a predicate to better match the error message from collatzConjecture.
   /// Knowing about predicates are not needed for completing this exercise,

--- a/exercises/practice/hamming/test/hamming_test.dart
+++ b/exercises/practice/hamming/test/hamming_test.dart
@@ -9,27 +9,27 @@ void main() {
 
   group('Hamming', () {
     test('empty strands', () {
-      final int result = hamming.distance('', '');
+      final result = hamming.distance('', '');
       expect(result, equals(0));
     }, skip: false);
 
     test('single letter identical strands', () {
-      final int result = hamming.distance('A', 'A');
+      final result = hamming.distance('A', 'A');
       expect(result, equals(0));
     }, skip: true);
 
     test('single letter different strands', () {
-      final int result = hamming.distance('G', 'T');
+      final result = hamming.distance('G', 'T');
       expect(result, equals(1));
     }, skip: true);
 
     test('long identical strands', () {
-      final int result = hamming.distance('GGACTGAAATCTG', 'GGACTGAAATCTG');
+      final result = hamming.distance('GGACTGAAATCTG', 'GGACTGAAATCTG');
       expect(result, equals(0));
     }, skip: true);
 
     test('long different strands', () {
-      final int result = hamming.distance('GGACGGATTCTG', 'AGGACGGATTCT');
+      final result = hamming.distance('GGACGGATTCTG', 'AGGACGGATTCT');
       expect(result, equals(9));
     }, skip: true);
 

--- a/exercises/practice/isbn-verifier/test/isbn_verifier_test.dart
+++ b/exercises/practice/isbn-verifier/test/isbn_verifier_test.dart
@@ -4,97 +4,97 @@ import 'package:test/test.dart';
 void main() {
   group('IsbnVerifier', () {
     test('valid isbn', () {
-      final bool result = isValid('3-598-21508-8');
+      final result = isValid('3-598-21508-8');
       expect(result, equals(true));
     }, skip: false);
 
     test('invalid isbn check digit', () {
-      final bool result = isValid('3-598-21508-9');
+      final result = isValid('3-598-21508-9');
       expect(result, equals(false));
     }, skip: true);
 
     test('valid isbn with a check digit of 10', () {
-      final bool result = isValid('3-598-21507-X');
+      final result = isValid('3-598-21507-X');
       expect(result, equals(true));
     }, skip: true);
 
     test('check digit is a character other than X', () {
-      final bool result = isValid('3-598-21507-A');
+      final result = isValid('3-598-21507-A');
       expect(result, equals(false));
     }, skip: true);
 
     test('invalid check digit in isbn is not treated as zero', () {
-      final bool result = isValid('4-598-21507-B');
+      final result = isValid('4-598-21507-B');
       expect(result, equals(false));
     }, skip: true);
 
     test('invalid character in isbn is not treated as zero', () {
-      final bool result = isValid('3-598-P1581-X');
+      final result = isValid('3-598-P1581-X');
       expect(result, equals(false));
     }, skip: true);
 
     test('X is only valid as a check digit', () {
-      final bool result = isValid('3-598-2X507-9');
+      final result = isValid('3-598-2X507-9');
       expect(result, equals(false));
     }, skip: true);
 
     test('valid isbn without separating dashes', () {
-      final bool result = isValid('3598215088');
+      final result = isValid('3598215088');
       expect(result, equals(true));
     }, skip: true);
 
     test('isbn without separating dashes and X as check digit', () {
-      final bool result = isValid('359821507X');
+      final result = isValid('359821507X');
       expect(result, equals(true));
     }, skip: true);
 
     test('isbn without check digit and dashes', () {
-      final bool result = isValid('359821507');
+      final result = isValid('359821507');
       expect(result, equals(false));
     }, skip: true);
 
     test('too long isbn and no dashes', () {
-      final bool result = isValid('3598215078X');
+      final result = isValid('3598215078X');
       expect(result, equals(false));
     }, skip: true);
 
     test('too short isbn', () {
-      final bool result = isValid('00');
+      final result = isValid('00');
       expect(result, equals(false));
     }, skip: true);
 
     test('isbn without check digit', () {
-      final bool result = isValid('3-598-21507');
+      final result = isValid('3-598-21507');
       expect(result, equals(false));
     }, skip: true);
 
     test('check digit of X should not be used for 0', () {
-      final bool result = isValid('3-598-21515-X');
+      final result = isValid('3-598-21515-X');
       expect(result, equals(false));
     }, skip: true);
 
     test('empty isbn', () {
-      final bool result = isValid('');
+      final result = isValid('');
       expect(result, equals(false));
     }, skip: true);
 
     test('input is 9 characters', () {
-      final bool result = isValid('134456729');
+      final result = isValid('134456729');
       expect(result, equals(false));
     }, skip: true);
 
     test('invalid characters are not ignored after checking length', () {
-      final bool result = isValid('3132P34035');
+      final result = isValid('3132P34035');
       expect(result, equals(false));
     }, skip: true);
 
     test('invalid characters are not ignored before checking length', () {
-      final bool result = isValid('3598P215088');
+      final result = isValid('3598P215088');
       expect(result, equals(false));
     }, skip: true);
 
     test('input is too long but contains a valid isbn', () {
-      final bool result = isValid('98245726788');
+      final result = isValid('98245726788');
       expect(result, equals(false));
     }, skip: true);
   });

--- a/exercises/practice/isogram/test/isogram_test.dart
+++ b/exercises/practice/isogram/test/isogram_test.dart
@@ -2,7 +2,7 @@ import 'package:isogram/isogram.dart';
 import 'package:test/test.dart';
 
 void main() {
-  final isogram = new Isogram();
+  final isogram = Isogram();
 
   group('Isogram', () {
     test('empty string', () {

--- a/exercises/practice/isogram/test/isogram_test.dart
+++ b/exercises/practice/isogram/test/isogram_test.dart
@@ -6,72 +6,72 @@ void main() {
 
   group('Isogram', () {
     test('empty string', () {
-      final bool result = isogram.isIsogram('');
+      final result = isogram.isIsogram('');
       expect(result, equals(true));
     }, skip: false);
 
     test('isogram with only lower case characters', () {
-      final bool result = isogram.isIsogram('isogram');
+      final result = isogram.isIsogram('isogram');
       expect(result, equals(true));
     }, skip: true);
 
     test('word with one duplicated character', () {
-      final bool result = isogram.isIsogram('eleven');
+      final result = isogram.isIsogram('eleven');
       expect(result, equals(false));
     }, skip: true);
 
     test('word with one duplicated character from the end of the alphabet', () {
-      final bool result = isogram.isIsogram('zzyzx');
+      final result = isogram.isIsogram('zzyzx');
       expect(result, equals(false));
     }, skip: true);
 
     test('longest reported english isogram', () {
-      final bool result = isogram.isIsogram('subdermatoglyphic');
+      final result = isogram.isIsogram('subdermatoglyphic');
       expect(result, equals(true));
     }, skip: true);
 
     test('word with duplicated character in mixed case', () {
-      final bool result = isogram.isIsogram('Alphabet');
+      final result = isogram.isIsogram('Alphabet');
       expect(result, equals(false));
     }, skip: true);
 
     test('word with duplicated character in mixed case, lowercase first', () {
-      final bool result = isogram.isIsogram('alphAbet');
+      final result = isogram.isIsogram('alphAbet');
       expect(result, equals(false));
     }, skip: true);
 
     test('hypothetical isogrammic word with hyphen', () {
-      final bool result = isogram.isIsogram('thumbscrew-japingly');
+      final result = isogram.isIsogram('thumbscrew-japingly');
       expect(result, equals(true));
     }, skip: true);
 
     test('hypothetical word with duplicated character following hyphen', () {
-      final bool result = isogram.isIsogram('thumbscrew-jappingly');
+      final result = isogram.isIsogram('thumbscrew-jappingly');
       expect(result, equals(false));
     }, skip: true);
 
     test('isogram with duplicated hyphen', () {
-      final bool result = isogram.isIsogram('six-year-old');
+      final result = isogram.isIsogram('six-year-old');
       expect(result, equals(true));
     }, skip: true);
 
     test('made-up name that is an isogram', () {
-      final bool result = isogram.isIsogram('Emily Jung Schwartzkopf');
+      final result = isogram.isIsogram('Emily Jung Schwartzkopf');
       expect(result, equals(true));
     }, skip: true);
 
     test('duplicated character in the middle', () {
-      final bool result = isogram.isIsogram('accentor');
+      final result = isogram.isIsogram('accentor');
       expect(result, equals(false));
     }, skip: true);
 
     test('same first and last characters', () {
-      final bool result = isogram.isIsogram('angola');
+      final result = isogram.isIsogram('angola');
       expect(result, equals(false));
     }, skip: true);
 
     test('word with duplicated character and with two hyphens', () {
-      final bool result = isogram.isIsogram('up-to-date');
+      final result = isogram.isIsogram('up-to-date');
       expect(result, equals(false));
     }, skip: true);
   });


### PR DESCRIPTION
Per #426, drop types for variable definitions when assigning
results in test suites.

This removes type definitions for test suites that have
been synced with problem-specifications recently.
