### PR TITLE
Sync pangram with problem-specifications

### DIFF
--- a/exercises/practice/pangram/.docs/instructions.md
+++ b/exercises/practice/pangram/.docs/instructions.md
@@ -1,9 +1,9 @@
 # Instructions
 
-Determine if a sentence is a pangram. A pangram (Greek: παν γράμμα, pan gramma,
-"every letter") is a sentence using every letter of the alphabet at least once.
+Determine if a sentence is a pangram.
+A pangram (Greek: παν γράμμα, pan gramma, "every letter") is a sentence using every letter of the alphabet at least once.
 The best known English pangram is:
+
 > The quick brown fox jumps over the lazy dog.
 
-The alphabet used consists of ASCII letters `a` to `z`, inclusive, and is case
-insensitive. Input will not contain non-ASCII symbols.
+The alphabet used consists of letters `a` to `z`, inclusive, and is case insensitive.

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -2,6 +2,9 @@
   "authors": [
     "amscotti"
   ],
+  "contributors": [
+    "kytrinyx"
+  ],
   "files": {
     "solution": [
       "lib/pangram.dart"

--- a/exercises/practice/pangram/.meta/tests.toml
+++ b/exercises/practice/pangram/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [64f61791-508e-4f5c-83ab-05de042b0149]
 description = "empty sentence"
@@ -31,3 +38,8 @@ description = "mixed case and punctuation"
 
 [2577bf54-83c8-402d-a64b-a2c0f7bb213a]
 description = "case insensitive"
+include = false
+
+[7138e389-83e4-4c6e-8413-1e40a0076951]
+description = "a-m and A-M are 26 different characters but not a pangram"
+reimplements = "2577bf54-83c8-402d-a64b-a2c0f7bb213a"

--- a/exercises/practice/pangram/test/pangram_test.dart
+++ b/exercises/practice/pangram/test/pangram_test.dart
@@ -2,59 +2,57 @@ import 'package:pangram/pangram.dart';
 import 'package:test/test.dart';
 
 void main() {
-  final pangram = new Pangram();
+  final pangram = Pangram();
 
   group('Pangram', () {
-    group('Check if the given string is a pangram', () {
-      test('sentence empty', () {
-        final bool result = pangram.isPangram('');
-        expect(result, equals(false));
-      }, skip: false);
+    test('empty sentence', () {
+      final result = pangram.isPangram('');
+      expect(result, equals(false));
+    }, skip: false);
 
-      test('recognizes a perfect lower case pangram', () {
-        final bool result = pangram.isPangram('abcdefghijklmnopqrstuvwxyz');
-        expect(result, equals(true));
-      }, skip: true);
+    test('perfect lower case', () {
+      final result = pangram.isPangram('abcdefghijklmnopqrstuvwxyz');
+      expect(result, equals(true));
+    }, skip: true);
 
-      test('pangram with only lower case', () {
-        final bool result = pangram.isPangram('the quick brown fox jumps over the lazy dog');
-        expect(result, equals(true));
-      }, skip: true);
+    test('only lower case', () {
+      final result = pangram.isPangram('the quick brown fox jumps over the lazy dog');
+      expect(result, equals(true));
+    }, skip: true);
 
-      test('missing character \'x\'', () {
-        final bool result = pangram.isPangram('a quick movement of the enemy will jeopardize five gunboats');
-        expect(result, equals(false));
-      }, skip: true);
+    test('missing the letter \'x\'', () {
+      final result = pangram.isPangram('a quick movement of the enemy will jeopardize five gunboats');
+      expect(result, equals(false));
+    }, skip: true);
 
-      test('another missing character, e.g. \'h\'', () {
-        final bool result = pangram.isPangram('five boxing wizards jump quickly at it');
-        expect(result, equals(false));
-      }, skip: true);
+    test('missing the letter \'h\'', () {
+      final result = pangram.isPangram('five boxing wizards jump quickly at it');
+      expect(result, equals(false));
+    }, skip: true);
 
-      test('pangram with underscores', () {
-        final bool result = pangram.isPangram('the_quick_brown_fox_jumps_over_the_lazy_dog');
-        expect(result, equals(true));
-      }, skip: true);
+    test('with underscores', () {
+      final result = pangram.isPangram('the_quick_brown_fox_jumps_over_the_lazy_dog');
+      expect(result, equals(true));
+    }, skip: true);
 
-      test('pangram with numbers', () {
-        final bool result = pangram.isPangram('the 1 quick brown fox jumps over the 2 lazy dogs');
-        expect(result, equals(true));
-      }, skip: true);
+    test('with numbers', () {
+      final result = pangram.isPangram('the 1 quick brown fox jumps over the 2 lazy dogs');
+      expect(result, equals(true));
+    }, skip: true);
 
-      test('missing letters replaced by numbers', () {
-        final bool result = pangram.isPangram('7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog');
-        expect(result, equals(false));
-      }, skip: true);
+    test('missing letters replaced by numbers', () {
+      final result = pangram.isPangram('7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog');
+      expect(result, equals(false));
+    }, skip: true);
 
-      test('pangram with mixed case and punctuation', () {
-        final bool result = pangram.isPangram('"Five quacking Zephyrs jolt my wax bed."');
-        expect(result, equals(true));
-      }, skip: true);
+    test('mixed case and punctuation', () {
+      final result = pangram.isPangram('"Five quacking Zephyrs jolt my wax bed."');
+      expect(result, equals(true));
+    }, skip: true);
 
-      test('upper and lower case versions of the same character should not be counted separately', () {
-        final bool result = pangram.isPangram('the quick brown fox jumps over with lazy FX');
-        expect(result, equals(false));
-      }, skip: true);
-    });
+    test('case insensitive', () {
+      final result = pangram.isPangram('the quick brown fox jumps over with lazy FX');
+      expect(result, equals(false));
+    }, skip: true);
   });
 }

--- a/exercises/practice/pangram/test/pangram_test.dart
+++ b/exercises/practice/pangram/test/pangram_test.dart
@@ -6,53 +6,53 @@ void main() {
 
   group('Pangram', () {
     group('Check if the given string is a pangram', () {
-      test("sentence empty", () {
-        final bool result = pangram.isPangram("");
+      test('sentence empty', () {
+        final bool result = pangram.isPangram('');
         expect(result, equals(false));
       }, skip: false);
 
-      test("recognizes a perfect lower case pangram", () {
-        final bool result = pangram.isPangram("abcdefghijklmnopqrstuvwxyz");
+      test('recognizes a perfect lower case pangram', () {
+        final bool result = pangram.isPangram('abcdefghijklmnopqrstuvwxyz');
         expect(result, equals(true));
       }, skip: true);
 
-      test("pangram with only lower case", () {
-        final bool result = pangram.isPangram("the quick brown fox jumps over the lazy dog");
+      test('pangram with only lower case', () {
+        final bool result = pangram.isPangram('the quick brown fox jumps over the lazy dog');
         expect(result, equals(true));
       }, skip: true);
 
-      test("missing character 'x'", () {
-        final bool result = pangram.isPangram("a quick movement of the enemy will jeopardize five gunboats");
+      test('missing character \'x\'', () {
+        final bool result = pangram.isPangram('a quick movement of the enemy will jeopardize five gunboats');
         expect(result, equals(false));
       }, skip: true);
 
-      test("another missing character, e.g. 'h'", () {
-        final bool result = pangram.isPangram("five boxing wizards jump quickly at it");
+      test('another missing character, e.g. \'h\'', () {
+        final bool result = pangram.isPangram('five boxing wizards jump quickly at it');
         expect(result, equals(false));
       }, skip: true);
 
-      test("pangram with underscores", () {
-        final bool result = pangram.isPangram("the_quick_brown_fox_jumps_over_the_lazy_dog");
+      test('pangram with underscores', () {
+        final bool result = pangram.isPangram('the_quick_brown_fox_jumps_over_the_lazy_dog');
         expect(result, equals(true));
       }, skip: true);
 
-      test("pangram with numbers", () {
-        final bool result = pangram.isPangram("the 1 quick brown fox jumps over the 2 lazy dogs");
+      test('pangram with numbers', () {
+        final bool result = pangram.isPangram('the 1 quick brown fox jumps over the 2 lazy dogs');
         expect(result, equals(true));
       }, skip: true);
 
-      test("missing letters replaced by numbers", () {
-        final bool result = pangram.isPangram("7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog");
+      test('missing letters replaced by numbers', () {
+        final bool result = pangram.isPangram('7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog');
         expect(result, equals(false));
       }, skip: true);
 
-      test("pangram with mixed case and punctuation", () {
-        final bool result = pangram.isPangram("\"Five quacking Zephyrs jolt my wax bed.\"");
+      test('pangram with mixed case and punctuation', () {
+        final bool result = pangram.isPangram('"Five quacking Zephyrs jolt my wax bed."');
         expect(result, equals(true));
       }, skip: true);
 
-      test("upper and lower case versions of the same character should not be counted separately", () {
-        final bool result = pangram.isPangram("the quick brown fox jumps over with lazy FX");
+      test('upper and lower case versions of the same character should not be counted separately', () {
+        final bool result = pangram.isPangram('the quick brown fox jumps over with lazy FX');
         expect(result, equals(false));
       }, skip: true);
     });

--- a/exercises/practice/pangram/test/pangram_test.dart
+++ b/exercises/practice/pangram/test/pangram_test.dart
@@ -50,8 +50,8 @@ void main() {
       expect(result, equals(true));
     }, skip: true);
 
-    test('case insensitive', () {
-      final result = pangram.isPangram('the quick brown fox jumps over with lazy FX');
+    test('a-m and A-M are 26 different characters but not a pangram', () {
+      final result = pangram.isPangram('abcdefghijklm ABCDEFGHIJKLM');
       expect(result, equals(false));
     }, skip: true);
   });


### PR DESCRIPTION
The first commit manually switches the existing pangram test suite to use single-quoted strings for the test descriptions, to help minimize the diff upon regenerating the test suite.
The second commit regenerates the test suite with the existing tests, to minimize the diff upon syncing with problem-specifications.
The third commit finally syncs with the upstream specification.