### PR TITLE
Sync word-count with problem-specifications

### DIFF
--- a/exercises/practice/word-count/.docs/instructions.md
+++ b/exercises/practice/word-count/.docs/instructions.md
@@ -12,7 +12,7 @@ When counting words you can assume the following rules:
 
 1. The count is _case insensitive_ (ie "You", "you", and "YOU" are 3 uses of the same word)
 2. The count is _unordered_; the tests will ignore how words and counts are ordered
-3. Other than the apostrophe in a _contraction_ all forms of _punctuation_ are ignored
+3. Other than the apostrophe in a _contraction_ all forms of _punctuation_ are regarded as spaces
 4. The words can be separated by _any_ form of whitespace (ie "\t", "\n", " ")
 
 For example, for the phrase `"That's the password: 'PASSWORD 123'!", cried the Special Agent.\nSo I fled.` the count would be:

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -3,7 +3,8 @@
     "devkabiir"
   ],
   "contributors": [
-    "Stargator"
+    "Stargator",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/word-count/.meta/lib/example.dart
+++ b/exercises/practice/word-count/.meta/lib/example.dart
@@ -9,7 +9,7 @@ class WordCount {
     ///  e.g. don't
     /// \\d+ matches one or more digits
     final allWords = <String>[];
-    var wordMatches = RegExp("\\w+'\\w|\\w+|d+").allMatches(input.toLowerCase());
+    var wordMatches = RegExp("\\w+'\\w+|\\w+|d+").allMatches(input.toLowerCase());
     for (var match in wordMatches) {
       allWords.add(match.group(0)!);
     }

--- a/exercises/practice/word-count/.meta/tests.toml
+++ b/exercises/practice/word-count/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [61559d5f-2cad-48fb-af53-d3973a9ee9ef]
 description = "count one word"
@@ -28,6 +35,11 @@ description = "normalize case"
 
 [4185a902-bdb0-4074-864c-f416e42a0f19]
 description = "with apostrophes"
+include = false
+
+[4ff6c7d7-fcfc-43ef-b8e7-34ff1837a2d3]
+description = "with apostrophes"
+reimplements = "4185a902-bdb0-4074-864c-f416e42a0f19"
 
 [be72af2b-8afe-4337-b151-b297202e4a7b]
 description = "with quotations"
@@ -40,3 +52,6 @@ description = "multiple spaces not detected as a word"
 
 [50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360]
 description = "alternating word separators not detected as a word"
+
+[6d00f1db-901c-4bec-9829-d20eb3044557]
+description = "quotation for word with apostrophe"

--- a/exercises/practice/word-count/test/word_count_test.dart
+++ b/exercises/practice/word-count/test/word_count_test.dart
@@ -46,8 +46,19 @@ void main() {
     }, skip: true);
 
     test('with apostrophes', () {
-      final result = wordCount.countWords('First: don\'t laugh. Then: don\'t cry.');
-      expect(result, equals(<String, int>{'first': 1, 'don\'t': 2, 'laugh': 1, 'then': 1, 'cry': 1}));
+      final result = wordCount.countWords('\'First: don\'t laugh. Then: don\'t cry. You\'re getting it.\'');
+      expect(
+          result,
+          equals(<String, int>{
+            'first': 1,
+            'don\'t': 2,
+            'laugh': 1,
+            'then': 1,
+            'cry': 1,
+            'you\'re': 1,
+            'getting': 1,
+            'it': 1
+          }));
     }, skip: true);
 
     test('with quotations', () {
@@ -71,6 +82,11 @@ void main() {
     test('alternating word separators not detected as a word', () {
       final result = wordCount.countWords(',\n,one,\n ,two \n \'three\'');
       expect(result, equals(<String, int>{'one': 1, 'two': 1, 'three': 1}));
+    }, skip: true);
+
+    test('quotation for word with apostrophe', () {
+      final result = wordCount.countWords('can, can\'t, \'can\'t\'');
+      expect(result, equals(<String, int>{'can': 1, 'can\'t': 2}));
     }, skip: true);
   });
 }

--- a/exercises/practice/word-count/test/word_count_test.dart
+++ b/exercises/practice/word-count/test/word_count_test.dart
@@ -1,85 +1,76 @@
 import 'package:test/test.dart';
 import 'package:word_count/word_count.dart';
 
-final wordCount = WordCount();
-
 void main() {
-  group("WordCount: Simple Tests - ", simpleTests);
-  group("WordCount: Ignore special characters - ", ignoreSpecialCharacters);
-  group("WordCount: Works with numbers too - ", notJustWords);
-  group("WordCount: Edge case - ", edgeCases);
-}
+  final wordCount = WordCount();
 
-void simpleTests() {
-  test('count one word', () {
-    final Map<String, int> result = wordCount.countWords('word');
-    expect(result, equals(<String, int>{'word': 1}));
-  }, skip: false);
+  group('WordCount', () {
+    test('count one word', () {
+      final result = wordCount.countWords('word');
+      expect(result, equals(<String, int>{'word': 1}));
+    }, skip: false);
 
-  test('count one of each word', () {
-    final Map<String, int> result = wordCount.countWords('one of each');
-    expect(result, equals(<String, int>{'one': 1, 'of': 1, 'each': 1}));
-  }, skip: true);
+    test('count one of each word', () {
+      final result = wordCount.countWords('one of each');
+      expect(result, equals(<String, int>{'one': 1, 'of': 1, 'each': 1}));
+    }, skip: true);
 
-  test('multiple occurrences of a word', () {
-    final Map<String, int> result = wordCount.countWords('one fish two fish red fish blue fish');
-    expect(result, equals(<String, int>{'one': 1, 'fish': 4, 'two': 1, 'red': 1, 'blue': 1}));
-  }, skip: true);
-}
+    test('multiple occurrences of a word', () {
+      final result = wordCount.countWords('one fish two fish red fish blue fish');
+      expect(result, equals(<String, int>{'one': 1, 'fish': 4, 'two': 1, 'red': 1, 'blue': 1}));
+    }, skip: true);
 
-void ignoreSpecialCharacters() {
-  test('handles cramped lists', () {
-    final Map<String, int> result = wordCount.countWords('one,two,three');
-    expect(result, equals(<String, int>{'one': 1, 'two': 1, 'three': 1}));
-  }, skip: true);
+    test('handles cramped lists', () {
+      final result = wordCount.countWords('one,two,three');
+      expect(result, equals(<String, int>{'one': 1, 'two': 1, 'three': 1}));
+    }, skip: true);
 
-  test('handles expanded lists', () {
-    final Map<String, int> result = wordCount.countWords('one,\ntwo,\nthree');
-    expect(result, equals(<String, int>{'one': 1, 'two': 1, 'three': 1}));
-  }, skip: true);
+    test('handles expanded lists', () {
+      final result = wordCount.countWords('one,\ntwo,\nthree');
+      expect(result, equals(<String, int>{'one': 1, 'two': 1, 'three': 1}));
+    }, skip: true);
 
-  test('ignore punctuation', () {
-    final Map<String, int> result = wordCount.countWords('car: carpet as java: javascript!!&@\$%^&');
-    expect(result, equals(<String, int>{'car': 1, 'carpet': 1, 'as': 1, 'java': 1, 'javascript': 1}));
-  }, skip: true);
+    test('ignore punctuation', () {
+      final result = wordCount.countWords('car: carpet as java: javascript!!&@\$%^&');
+      expect(result, equals(<String, int>{'car': 1, 'carpet': 1, 'as': 1, 'java': 1, 'javascript': 1}));
+    }, skip: true);
 
-  test('with quotations', () {
-    final Map<String, int> result = wordCount.countWords('Joe can\'t tell between \'large\' and large.');
-    expect(result, equals(<String, int>{'joe': 1, 'can\'t': 1, 'tell': 1, 'between': 1, 'large': 2, 'and': 1}));
-  }, skip: true);
-}
+    test('include numbers', () {
+      final result = wordCount.countWords('testing, 1, 2 testing');
+      expect(result, equals(<String, int>{'testing': 2, '1': 1, '2': 1}));
+    }, skip: true);
 
-void notJustWords() {
-  test('include numbers', () {
-    final Map<String, int> result = wordCount.countWords('testing, 1, 2 testing');
-    expect(result, equals(<String, int>{'testing': 2, '1': 1, '2': 1}));
-  }, skip: true);
-}
+    test('normalize case', () {
+      final result = wordCount.countWords('go Go GO Stop stop');
+      expect(result, equals(<String, int>{'go': 3, 'stop': 2}));
+    }, skip: true);
 
-void edgeCases() {
-  test('normalize case', () {
-    final Map<String, int> result = wordCount.countWords('go Go GO Stop stop');
-    expect(result, equals(<String, int>{'go': 3, 'stop': 2}));
-  }, skip: true);
+    test('with apostrophes', () {
+      final result = wordCount.countWords('First: don\'t laugh. Then: don\'t cry.');
+      expect(result, equals(<String, int>{'first': 1, 'don\'t': 2, 'laugh': 1, 'then': 1, 'cry': 1}));
+    }, skip: true);
 
-  test('with apostrophes', () {
-    final Map<String, int> result = wordCount.countWords('First: don\'t laugh. Then: don\'t cry.');
-    expect(result, equals(<String, int>{'first': 1, 'don\'t': 2, 'laugh': 1, 'then': 1, 'cry': 1}));
-  }, skip: true);
+    test('with quotations', () {
+      final result = wordCount.countWords('Joe can\'t tell between \'large\' and large.');
+      expect(result, equals(<String, int>{'joe': 1, 'can\'t': 1, 'tell': 1, 'between': 1, 'large': 2, 'and': 1}));
+    }, skip: true);
 
-  test('substrings from the beginning', () {
-    final Map<String, int> result = wordCount.countWords('Joe can\'t tell between app, apple and a.');
-    expect(result,
-        equals(<String, int>{'joe': 1, 'can\'t': 1, 'tell': 1, 'between': 1, 'app': 1, 'apple': 1, 'and': 1, 'a': 1}));
-  }, skip: true);
+    test('substrings from the beginning', () {
+      final result = wordCount.countWords('Joe can\'t tell between app, apple and a.');
+      expect(
+          result,
+          equals(
+              <String, int>{'joe': 1, 'can\'t': 1, 'tell': 1, 'between': 1, 'app': 1, 'apple': 1, 'and': 1, 'a': 1}));
+    }, skip: true);
 
-  test('multiple spaces not detected as a word', () {
-    final Map<String, int> result = wordCount.countWords(' multiple   whitespaces');
-    expect(result, equals(<String, int>{'multiple': 1, 'whitespaces': 1}));
-  }, skip: true);
+    test('multiple spaces not detected as a word', () {
+      final result = wordCount.countWords(' multiple   whitespaces');
+      expect(result, equals(<String, int>{'multiple': 1, 'whitespaces': 1}));
+    }, skip: true);
 
-  test('alternating word separators not detected as a word', () {
-    final Map<String, int> result = wordCount.countWords(',\n,one,\n ,two \n \'three\'');
-    expect(result, equals(<String, int>{'one': 1, 'two': 1, 'three': 1}));
-  }, skip: true);
+    test('alternating word separators not detected as a word', () {
+      final result = wordCount.countWords(',\n,one,\n ,two \n \'three\'');
+      expect(result, equals(<String, int>{'one': 1, 'two': 1, 'three': 1}));
+    }, skip: true);
+  });
 }


### PR DESCRIPTION
The first commit regenerates the word-count exercise based on the previously selected test cases, in order to minimize the diff when syncing.

Note that the problem-specification did not group the tests, so regenerating it removed the manually-created grouping.

The second commit syncs with problem-specifications. This brought in two new tests. The example solution had to be tweaked to pass the updated test suite.

<details>
<summary>Failed test</summary>

```
00:00 +8: test/word_count_test.dart: WordCount with apostrophes                                                                                                   00:00 +8 -1: test/word_count_test.dart: WordCount with apostrophes [E]                                                                                                                                 
  Expected: {
              'first': 1,
              'don\'t': 2,
              'laugh': 1,
              'then': 1,
              'cry': 1,
              'you\'re': 1,
              'getting': 1,
              'it': 1
            }
    Actual: {
              'first': 1,
              'don\'t': 2,
              'laugh': 1,
              'then': 1,
              'cry': 1,
              'you\'r': 1,
              'e': 1,
              'getting': 1,
              'it': 1
            }
     Which: has different length and is missing map key 'you\'re'
  
  package:test_api                expect
  test/word_count_test.dart 50:7  main.<fn>.<fn>
```

</details>