### PR TITLE
Sync luhn from problem-specifications

### DIFF
--- a/exercises/practice/luhn/.docs/instructions.md
+++ b/exercises/practice/luhn/.docs/instructions.md
@@ -2,35 +2,31 @@
 
 Given a number determine whether or not it is valid per the Luhn formula.
 
-The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is
-a simple checksum formula used to validate a variety of identification
-numbers, such as credit card numbers and Canadian Social Insurance
-Numbers.
+The [Luhn algorithm][luhn] is a simple checksum formula used to validate a variety of identification numbers, such as credit card numbers and Canadian Social Insurance Numbers.
 
 The task is to check if a given string is valid.
 
-Validating a Number
-------
+## Validating a Number
 
-Strings of length 1 or less are not valid. Spaces are allowed in the input,
-but they should be stripped before checking. All other non-digit characters
-are disallowed.
+Strings of length 1 or less are not valid.
+Spaces are allowed in the input, but they should be stripped before checking.
+All other non-digit characters are disallowed.
 
-## Example 1: valid credit card number
+### Example 1: valid credit card number
 
 ```text
 4539 3195 0343 6467
 ```
 
-The first step of the Luhn algorithm is to double every second digit,
-starting from the right. We will be doubling
+The first step of the Luhn algorithm is to double every second digit, starting from the right.
+We will be doubling
 
 ```text
 4_3_ 3_9_ 0_4_ 6_6_
 ```
 
-If doubling the number results in a number greater than 9 then subtract 9
-from the product. The results of our doubling:
+If doubling the number results in a number greater than 9 then subtract 9 from the product.
+The results of our doubling:
 
 ```text
 8569 6195 0383 3437
@@ -42,9 +38,10 @@ Then sum all of the digits:
 8+5+6+9+6+1+9+5+0+3+8+3+3+4+3+7 = 80
 ```
 
-If the sum is evenly divisible by 10, then the number is valid. This number is valid!
+If the sum is evenly divisible by 10, then the number is valid.
+This number is valid!
 
-## Example 2: invalid credit card number
+### Example 2: invalid credit card number
 
 ```text
 8273 1232 7352 0569
@@ -63,3 +60,5 @@ Sum the digits
 ```
 
 57 is not evenly divisible by 10, so this number is not valid.
+
+[luhn]: https://en.wikipedia.org/wiki/Luhn_algorithm

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -2,6 +2,9 @@
   "authors": [
     "amscotti"
   ],
+  "contributors": [
+    "kytrinyx"
+  ],
   "files": {
     "solution": [
       "lib/luhn.dart"

--- a/exercises/practice/luhn/.meta/tests.toml
+++ b/exercises/practice/luhn/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [792a7082-feb7-48c7-b88b-bbfec160865e]
 description = "single digit strings can not be valid"
@@ -26,6 +33,9 @@ description = "invalid credit card"
 [20e67fad-2121-43ed-99a8-14b5b856adb9]
 description = "invalid long number with an even remainder"
 
+[7e7c9fc1-d994-457c-811e-d390d52fba5e]
+description = "invalid long number with a remainder divisible by 5"
+
 [ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa]
 description = "valid number with an even number of digits"
 
@@ -50,8 +60,17 @@ description = "more than a single zero is valid"
 [ab56fa80-5de8-4735-8a4a-14dae588663e]
 description = "input digit 9 is correctly converted to output digit 9"
 
+[b9887ee8-8337-46c5-bc45-3bcab51bc36f]
+description = "very long input is valid"
+
+[8a7c0e24-85ea-4154-9cf1-c2db90eabc08]
+description = "valid luhn with an odd number of digits and non zero first digit"
+
 [39a06a5a-5bad-4e0f-b215-b042d46209b1]
 description = "using ascii value for non-doubled non-digit isn't allowed"
 
 [f94cf191-a62f-4868-bc72-7253114aa157]
 description = "using ascii value for doubled non-digit isn't allowed"
+
+[8b72ad26-c8be-49a2-b99c-bcc3bf631b33]
+description = "non-numeric, non-space char in the middle with a sum that's divisible by 10 isn't allowed"

--- a/exercises/practice/luhn/test/luhn_test.dart
+++ b/exercises/practice/luhn/test/luhn_test.dart
@@ -2,86 +2,96 @@ import 'package:luhn/luhn.dart';
 import 'package:test/test.dart';
 
 void main() {
-  final luhn = new Luhn();
+  final luhn = Luhn();
 
   group('Luhn', () {
     test('single digit strings can not be valid', () {
-      final bool result = luhn.valid('1');
+      final result = luhn.valid('1');
       expect(result, equals(false));
     }, skip: false);
 
     test('a single zero is invalid', () {
-      final bool result = luhn.valid('0');
+      final result = luhn.valid('0');
       expect(result, equals(false));
     }, skip: true);
 
     test('a simple valid SIN that remains valid if reversed', () {
-      final bool result = luhn.valid('059');
+      final result = luhn.valid('059');
       expect(result, equals(true));
     }, skip: true);
 
     test('a simple valid SIN that becomes invalid if reversed', () {
-      final bool result = luhn.valid('59');
+      final result = luhn.valid('59');
       expect(result, equals(true));
     }, skip: true);
 
     test('a valid Canadian SIN', () {
-      final bool result = luhn.valid('055 444 285');
+      final result = luhn.valid('055 444 285');
       expect(result, equals(true));
     }, skip: true);
 
     test('invalid Canadian SIN', () {
-      final bool result = luhn.valid('055 444 286');
+      final result = luhn.valid('055 444 286');
       expect(result, equals(false));
     }, skip: true);
 
     test('invalid credit card', () {
-      final bool result = luhn.valid('8273 1232 7352 0569');
+      final result = luhn.valid('8273 1232 7352 0569');
+      expect(result, equals(false));
+    }, skip: true);
+
+    test('invalid long number with an even remainder', () {
+      final result = luhn.valid('1 2345 6789 1234 5678 9012');
       expect(result, equals(false));
     }, skip: true);
 
     test('valid number with an even number of digits', () {
-      final bool result = luhn.valid('095 245 88');
+      final result = luhn.valid('095 245 88');
+      expect(result, equals(true));
+    }, skip: true);
+
+    test('valid number with an odd number of spaces', () {
+      final result = luhn.valid('234 567 891 234');
       expect(result, equals(true));
     }, skip: true);
 
     test('valid strings with a non-digit added at the end become invalid', () {
-      final bool result = luhn.valid('059a');
+      final result = luhn.valid('059a');
       expect(result, equals(false));
     }, skip: true);
 
     test('valid strings with punctuation included become invalid', () {
-      final bool result = luhn.valid('055-444-285');
+      final result = luhn.valid('055-444-285');
       expect(result, equals(false));
     }, skip: true);
 
     test('valid strings with symbols included become invalid', () {
-      final bool result = luhn.valid('055£ 444\$ 285');
+      final result = luhn.valid('055# 444\$ 285');
       expect(result, equals(false));
     }, skip: true);
 
     test('single zero with space is invalid', () {
-      final bool result = luhn.valid(' 0');
+      final result = luhn.valid(' 0');
       expect(result, equals(false));
     }, skip: true);
 
     test('more than a single zero is valid', () {
-      final bool result = luhn.valid('0000 0');
+      final result = luhn.valid('0000 0');
       expect(result, equals(true));
     }, skip: true);
 
     test('input digit 9 is correctly converted to output digit 9', () {
-      final bool result = luhn.valid('091');
+      final result = luhn.valid('091');
       expect(result, equals(true));
     }, skip: true);
 
     test('using ascii value for non-doubled non-digit isn\'t allowed', () {
-      final bool result = luhn.valid('055b 444 285');
+      final result = luhn.valid('055b 444 285');
       expect(result, equals(false));
     }, skip: true);
 
     test('using ascii value for doubled non-digit isn\'t allowed', () {
-      final bool result = luhn.valid(':9');
+      final result = luhn.valid(':9');
       expect(result, equals(false));
     }, skip: true);
   });

--- a/exercises/practice/luhn/test/luhn_test.dart
+++ b/exercises/practice/luhn/test/luhn_test.dart
@@ -45,6 +45,11 @@ void main() {
       expect(result, equals(false));
     }, skip: true);
 
+    test('invalid long number with a remainder divisible by 5', () {
+      final result = luhn.valid('1 2345 6789 1234 5678 9013');
+      expect(result, equals(false));
+    }, skip: true);
+
     test('valid number with an even number of digits', () {
       final result = luhn.valid('095 245 88');
       expect(result, equals(true));
@@ -85,6 +90,16 @@ void main() {
       expect(result, equals(true));
     }, skip: true);
 
+    test('very long input is valid', () {
+      final result = luhn.valid('9999999999 9999999999 9999999999 9999999999');
+      expect(result, equals(true));
+    }, skip: true);
+
+    test('valid luhn with an odd number of digits and non zero first digit', () {
+      final result = luhn.valid('109');
+      expect(result, equals(true));
+    }, skip: true);
+
     test('using ascii value for non-doubled non-digit isn\'t allowed', () {
       final result = luhn.valid('055b 444 285');
       expect(result, equals(false));
@@ -92,6 +107,11 @@ void main() {
 
     test('using ascii value for doubled non-digit isn\'t allowed', () {
       final result = luhn.valid(':9');
+      expect(result, equals(false));
+    }, skip: true);
+
+    test('non-numeric, non-space char in the middle with a sum that\'s divisible by 10 isn\'t allowed', () {
+      final result = luhn.valid('59%59');
       expect(result, equals(false));
     }, skip: true);
   });

--- a/exercises/practice/luhn/test/luhn_test.dart
+++ b/exercises/practice/luhn/test/luhn_test.dart
@@ -5,83 +5,83 @@ void main() {
   final luhn = new Luhn();
 
   group('Luhn', () {
-    test("single digit strings can not be valid", () {
-      final bool result = luhn.valid("1");
+    test('single digit strings can not be valid', () {
+      final bool result = luhn.valid('1');
       expect(result, equals(false));
     }, skip: false);
 
-    test("a single zero is invalid", () {
-      final bool result = luhn.valid("0");
+    test('a single zero is invalid', () {
+      final bool result = luhn.valid('0');
       expect(result, equals(false));
     }, skip: true);
 
-    test("a simple valid SIN that remains valid if reversed", () {
-      final bool result = luhn.valid("059");
+    test('a simple valid SIN that remains valid if reversed', () {
+      final bool result = luhn.valid('059');
       expect(result, equals(true));
     }, skip: true);
 
-    test("a simple valid SIN that becomes invalid if reversed", () {
-      final bool result = luhn.valid("59");
+    test('a simple valid SIN that becomes invalid if reversed', () {
+      final bool result = luhn.valid('59');
       expect(result, equals(true));
     }, skip: true);
 
-    test("a valid Canadian SIN", () {
-      final bool result = luhn.valid("055 444 285");
+    test('a valid Canadian SIN', () {
+      final bool result = luhn.valid('055 444 285');
       expect(result, equals(true));
     }, skip: true);
 
-    test("invalid Canadian SIN", () {
-      final bool result = luhn.valid("055 444 286");
+    test('invalid Canadian SIN', () {
+      final bool result = luhn.valid('055 444 286');
       expect(result, equals(false));
     }, skip: true);
 
-    test("invalid credit card", () {
-      final bool result = luhn.valid("8273 1232 7352 0569");
+    test('invalid credit card', () {
+      final bool result = luhn.valid('8273 1232 7352 0569');
       expect(result, equals(false));
     }, skip: true);
 
-    test("valid number with an even number of digits", () {
-      final bool result = luhn.valid("095 245 88");
+    test('valid number with an even number of digits', () {
+      final bool result = luhn.valid('095 245 88');
       expect(result, equals(true));
     }, skip: true);
 
-    test("valid strings with a non-digit added at the end become invalid", () {
-      final bool result = luhn.valid("059a");
+    test('valid strings with a non-digit added at the end become invalid', () {
+      final bool result = luhn.valid('059a');
       expect(result, equals(false));
     }, skip: true);
 
-    test("valid strings with punctuation included become invalid", () {
-      final bool result = luhn.valid("055-444-285");
+    test('valid strings with punctuation included become invalid', () {
+      final bool result = luhn.valid('055-444-285');
       expect(result, equals(false));
     }, skip: true);
 
-    test("valid strings with symbols included become invalid", () {
-      final bool result = luhn.valid("055£ 444\$ 285");
+    test('valid strings with symbols included become invalid', () {
+      final bool result = luhn.valid('055£ 444\$ 285');
       expect(result, equals(false));
     }, skip: true);
 
-    test("single zero with space is invalid", () {
-      final bool result = luhn.valid(" 0");
+    test('single zero with space is invalid', () {
+      final bool result = luhn.valid(' 0');
       expect(result, equals(false));
     }, skip: true);
 
-    test("more than a single zero is valid", () {
-      final bool result = luhn.valid("0000 0");
+    test('more than a single zero is valid', () {
+      final bool result = luhn.valid('0000 0');
       expect(result, equals(true));
     }, skip: true);
 
-    test("input digit 9 is correctly converted to output digit 9", () {
-      final bool result = luhn.valid("091");
+    test('input digit 9 is correctly converted to output digit 9', () {
+      final bool result = luhn.valid('091');
       expect(result, equals(true));
     }, skip: true);
 
-    test("using ascii value for non-doubled non-digit isn't allowed", () {
-      final bool result = luhn.valid("055b 444 285");
+    test('using ascii value for non-doubled non-digit isn\'t allowed', () {
+      final bool result = luhn.valid('055b 444 285');
       expect(result, equals(false));
     }, skip: true);
 
-    test("using ascii value for doubled non-digit isn't allowed", () {
-      final bool result = luhn.valid(":9");
+    test('using ascii value for doubled non-digit isn\'t allowed', () {
+      final bool result = luhn.valid(':9');
       expect(result, equals(false));
     }, skip: true);
   });


### PR DESCRIPTION
The first commit manually updates strings to use single-quotes rather than double-quotes, in order to minimize the diff when regenerating. The second commit regenerates the test suite based on the existing `tests.toml` file, which surprisingly added new tests. The third commit syncs with problem-specifications, which adds even more tests. None of the tests had any surprises, though; just more edge cases. The existing example solution didn't need to be updated at all.