### PR TITLE
Sync gigasecond with problem-specifications

### DIFF
--- a/exercises/practice/gigasecond/.docs/instructions.md
+++ b/exercises/practice/gigasecond/.docs/instructions.md
@@ -1,6 +1,5 @@
 # Instructions
 
-Given a moment, determine the moment that would be after a gigasecond
-has passed.
+Given a moment, determine the moment that would be after a gigasecond has passed.
 
 A gigasecond is 10^9 (1,000,000,000) seconds.

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -5,7 +5,8 @@
   "contributors": [
     "rafaelalvessa",
     "Stargator",
-    "Zureka"
+    "Zureka",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/gigasecond/.meta/lib/example.dart
+++ b/exercises/practice/gigasecond/.meta/lib/example.dart
@@ -1,3 +1,3 @@
-DateTime add(final DateTime birthDate) {
-  return birthDate.add(Duration(seconds: 1000000000));
+DateTime addGigasecondTo(final DateTime moment) {
+  return moment.add(Duration(seconds: 1000000000));
 }

--- a/exercises/practice/gigasecond/.meta/tests.toml
+++ b/exercises/practice/gigasecond/.meta/tests.toml
@@ -4,12 +4,15 @@
 
 [92fbe71c-ea52-4fac-bd77-be38023cacf7]
 description = "date only specification of time"
+include = false
 
 [6d86dd16-6f7a-47be-9e58-bb9fb2ae1433]
 description = "second test for date only specification of time"
+include = false
 
 [77eb8502-2bca-4d92-89d9-7b39ace28dd5]
 description = "third test for date only specification of time"
+include = false
 
 [c9d89a7d-06f8-4e28-a305-64f1b2abc693]
 description = "full time specified"

--- a/exercises/practice/gigasecond/.meta/tests.toml
+++ b/exercises/practice/gigasecond/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [92fbe71c-ea52-4fac-bd77-be38023cacf7]
 description = "date only specification of time"
@@ -19,3 +26,7 @@ description = "full time specified"
 
 [09d4e30e-728a-4b52-9005-be44a58d9eba]
 description = "full time with day roll-over"
+
+[fcec307c-7529-49ab-b0fe-20309197618a]
+description = "does not mutate the input"
+include = false

--- a/exercises/practice/gigasecond/test/gigasecond_test.dart
+++ b/exercises/practice/gigasecond/test/gigasecond_test.dart
@@ -2,49 +2,19 @@ import 'package:gigasecond/gigasecond.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group("Gigasecond", gigasecondTests);
-}
-
-void gigasecondTests() {
-  group('Add one gigasecond to the input. ', () {
-    test('date only specification of time', () {
-      final DateTime birthDate = DateTime.utc(2011, DateTime.april, 25);
-      final DateTime result = add(birthDate);
-      DateTime expectedDate = DateTime.utc(2043, DateTime.january, 1, 1, 46, 40);
-
-      expect(result, equals(expectedDate));
+  group('Gigasecond', () {
+    test('full time specified', () {
+      final moment = DateTime.utc(2015, DateTime.january, 24, 22, 00, 00);
+      final result = add(moment);
+      final expected = DateTime.utc(2046, DateTime.october, 02, 23, 46, 40);
+      expect(result, equals(expected));
     }, skip: false);
 
-    test('second test for date only specification of time', () {
-      final DateTime birthDate = DateTime.utc(1977, DateTime.june, 13);
-      final DateTime result = add(birthDate);
-      DateTime expectedDate = DateTime.utc(2009, DateTime.february, 19, 1, 46, 40);
-
-      expect(result, equals(expectedDate));
-    }, skip: true);
-
-    test('third test for date only specification of time', () {
-      final DateTime birthDate = DateTime.utc(1959, DateTime.july, 19);
-      final DateTime result = add(birthDate);
-      DateTime expectedDate = DateTime.utc(1991, DateTime.march, 27, 1, 46, 40);
-
-      expect(result, equals(expectedDate));
-    }, skip: true);
-
-    test('full time specified', () {
-      final DateTime birthDate = DateTime.utc(2015, DateTime.january, 24, 22, 00, 00);
-      final DateTime result = add(birthDate);
-      DateTime expectedDate = DateTime.utc(2046, DateTime.october, 2, 23, 46, 40);
-
-      expect(result, equals(expectedDate));
-    }, skip: true);
-
     test('full time with day roll-over', () {
-      final DateTime birthDate = DateTime.utc(2015, DateTime.january, 24, 23, 59, 59);
-      final DateTime result = add(birthDate);
-      DateTime expectedDate = DateTime.utc(2046, DateTime.october, 3, 01, 46, 39);
-
-      expect(result, equals(expectedDate));
+      final moment = DateTime.utc(2015, DateTime.january, 24, 23, 59, 59);
+      final result = add(moment);
+      final expected = DateTime.utc(2046, DateTime.october, 03, 01, 46, 39);
+      expect(result, equals(expected));
     }, skip: true);
   });
 }

--- a/exercises/practice/gigasecond/test/gigasecond_test.dart
+++ b/exercises/practice/gigasecond/test/gigasecond_test.dart
@@ -5,14 +5,14 @@ void main() {
   group('Gigasecond', () {
     test('full time specified', () {
       final moment = DateTime.utc(2015, DateTime.january, 24, 22, 00, 00);
-      final result = add(moment);
+      final result = addGigasecondTo(moment);
       final expected = DateTime.utc(2046, DateTime.october, 02, 23, 46, 40);
       expect(result, equals(expected));
     }, skip: false);
 
     test('full time with day roll-over', () {
       final moment = DateTime.utc(2015, DateTime.january, 24, 23, 59, 59);
-      final result = add(moment);
+      final result = addGigasecondTo(moment);
       final expected = DateTime.utc(2046, DateTime.october, 03, 01, 46, 39);
       expect(result, equals(expected));
     }, skip: true);


### PR DESCRIPTION
The first commit regenerates the test suite. I decided to remove the three first tests, as they are all redundant,
keeping only the two that are specified in the problem-specifications
using full datetimes as opposed to just dates.

The second commit syncs with problem-specifications. The sync updated the instructions.
There was an additional test that I chose not to include, as it
is a test for immutability, but as far as I can tell, the Dart
DateTime type is immutable already, so the test doesn't make
sense here.