### PR TITLE
Sync phone-number with problem-specifications

### DIFF
--- a/exercises/practice/phone-number/.docs/instructions.md
+++ b/exercises/practice/phone-number/.docs/instructions.md
@@ -2,9 +2,11 @@
 
 Clean up user-entered phone numbers so that they can be sent SMS messages.
 
-The **North American Numbering Plan (NANP)** is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda. All NANP-countries share the same international country code: `1`.
+The **North American Numbering Plan (NANP)** is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda.
+All NANP-countries share the same international country code: `1`.
 
-NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as *area code*, followed by a seven-digit local number. The first three digits of the local number represent the *exchange code*, followed by the unique four-digit number which is the *subscriber number*.
+NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as *area code*, followed by a seven-digit local number.
+The first three digits of the local number represent the *exchange code*, followed by the unique four-digit number which is the *subscriber number*.
 
 The format is usually represented as
 
@@ -17,6 +19,7 @@ where `N` is any digit from 2 through 9 and `X` is any digit from 0 through 9.
 Your task is to clean up differently formatted telephone numbers by removing punctuation and the country code (1) if present.
 
 For example, the inputs
+
 - `+1 (613)-995-0253`
 - `613-995-0253`
 - `1 613 995 0253`

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -18,6 +18,6 @@
     ]
   },
   "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
-  "source": "Event Manager by JumpstartLab",
-  "source_url": "http://tutorials.jumpstartlab.com/projects/eventmanager.html"
+  "source": "Exercise by the JumpstartLab team for students at The Turing School of Software and Design.",
+  "source_url": "https://turing.edu"
 }

--- a/exercises/practice/phone-number/.meta/tests.toml
+++ b/exercises/practice/phone-number/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [79666dce-e0f1-46de-95a1-563802913c35]
 description = "cleans the number"
@@ -28,9 +35,19 @@ description = "invalid when more than 11 digits"
 
 [63f38f37-53f6-4a5f-bd86-e9b404f10a60]
 description = "invalid with letters"
+include = false
+
+[eb8a1fc0-64e5-46d3-b0c6-33184208e28a]
+description = "invalid with letters"
+reimplements = "63f38f37-53f6-4a5f-bd86-e9b404f10a60"
 
 [4bd97d90-52fd-45d3-b0db-06ab95b1244e]
 description = "invalid with punctuations"
+include = false
+
+[065f6363-8394-4759-b080-e6c8c351dd1f]
+description = "invalid with punctuations"
+reimplements = "4bd97d90-52fd-45d3-b0db-06ab95b1244e"
 
 [d77d07f8-873c-4b17-8978-5f66139bf7d7]
 description = "invalid if area code starts with 0"

--- a/exercises/practice/phone-number/test/phone_number_test.dart
+++ b/exercises/practice/phone-number/test/phone_number_test.dart
@@ -1,128 +1,120 @@
 import 'package:phone_number/phone_number.dart';
 import 'package:test/test.dart';
 
-final phoneNumber = PhoneNumber();
-
 void main() {
-  group('PhoneNumber: Cleanup special characters - ', cleanUpTest);
-  group('PhoneNumber: Number length - ', numberLengthTest);
-  group('PhoneNumber: Accept only numbers - ', numbersOnlyTest);
-  group('PhoneNumber: Area/Exchange Code - ', areaCodeTests);
-  group('PhoneNumber: Edge cases - ', exchangeCodeTests);
-}
+  final phoneNumber = PhoneNumber();
 
-void cleanUpTest() {
-  test('cleans the number', () {
-    final String? result = phoneNumber.clean('(223) 456-7890');
-    expect(result, equals('2234567890'));
-  }, skip: false);
+  group('PhoneNumber', () {
+    test('cleans the number', () {
+      final result = phoneNumber.clean('(223) 456-7890');
+      expect(result, equals('2234567890'));
+    }, skip: false);
 
-  test('cleans numbers with dots', () {
-    final String? result = phoneNumber.clean('223.456.7890');
-    expect(result, equals('2234567890'));
-  }, skip: true);
+    test('cleans numbers with dots', () {
+      final result = phoneNumber.clean('223.456.7890');
+      expect(result, equals('2234567890'));
+    }, skip: true);
 
-  test('cleans numbers with multiple spaces', () {
-    final String? result = phoneNumber.clean('223 456   7890   ');
-    expect(result, equals('2234567890'));
-  }, skip: true);
-}
+    test('cleans numbers with multiple spaces', () {
+      final result = phoneNumber.clean('223 456   7890   ');
+      expect(result, equals('2234567890'));
+    }, skip: true);
 
-void numberLengthTest() {
-  test('invalid when 9 digits', () {
-    expect(() => phoneNumber.clean('123456789'),
-        throwsA(predicate<FormatException>((e) => e is FormatException && e.message == 'incorrect number of digits')));
-  }, skip: true);
+    test('invalid when 9 digits', () {
+      expect(
+          () => phoneNumber.clean('123456789'),
+          throwsA(
+              predicate<FormatException>((e) => e is FormatException && e.message == 'incorrect number of digits')));
+    }, skip: true);
 
-  test('invalid when 11 digits does not start with a 1', () {
-    expect(() => phoneNumber.clean('22234567890'),
-        throwsA(predicate<FormatException>((e) => e is FormatException && e.message == '11 digits must start with 1')));
-  }, skip: true);
+    test('invalid when 11 digits does not start with a 1', () {
+      expect(
+          () => phoneNumber.clean('22234567890'),
+          throwsA(
+              predicate<FormatException>((e) => e is FormatException && e.message == '11 digits must start with 1')));
+    }, skip: true);
 
-  test('valid when 11 digits and starting with 1', () {
-    final String? result = phoneNumber.clean('12234567890');
-    expect(result, equals('2234567890'));
-  }, skip: true);
+    test('valid when 11 digits and starting with 1', () {
+      final result = phoneNumber.clean('12234567890');
+      expect(result, equals('2234567890'));
+    }, skip: true);
 
-  test('valid when 11 digits and starting with 1 even with punctuation', () {
-    final String? result = phoneNumber.clean('+1 (223) 456-7890');
-    expect(result, equals('2234567890'));
-  }, skip: true);
+    test('valid when 11 digits and starting with 1 even with punctuation', () {
+      final result = phoneNumber.clean('+1 (223) 456-7890');
+      expect(result, equals('2234567890'));
+    }, skip: true);
 
-  test('invalid when more than 11 digits', () {
-    expect(() => phoneNumber.clean('321234567890'),
-        throwsA(predicate<FormatException>((e) => e is FormatException && e.message == 'more than 11 digits')));
-  }, skip: true);
-}
+    test('invalid when more than 11 digits', () {
+      expect(() => phoneNumber.clean('321234567890'),
+          throwsA(predicate<FormatException>((e) => e is FormatException && e.message == 'more than 11 digits')));
+    }, skip: true);
 
-void numbersOnlyTest() {
-  test('invalid with letters', () {
-    expect(() => phoneNumber.clean('123-abc-7890'),
-        throwsA(predicate<FormatException>((e) => e is FormatException && e.message == 'letters not permitted')));
-  }, skip: true);
+    test('invalid with letters', () {
+      expect(() => phoneNumber.clean('123-abc-7890'),
+          throwsA(predicate<FormatException>((e) => e is FormatException && e.message == 'letters not permitted')));
+    }, skip: true);
 
-  test('invalid with punctuations', () {
-    expect(() => phoneNumber.clean('123-@:!-7890'),
-        throwsA(predicate<FormatException>((e) => e is FormatException && e.message == 'punctuations not permitted')));
-  }, skip: true);
-}
+    test('invalid with punctuations', () {
+      expect(
+          () => phoneNumber.clean('123-@:!-7890'),
+          throwsA(
+              predicate<FormatException>((e) => e is FormatException && e.message == 'punctuations not permitted')));
+    }, skip: true);
 
-void areaCodeTests() {
-  test('invalid if area code starts with 0', () {
-    expect(
-        () => phoneNumber.clean('(023) 456-7890'),
-        throwsA(predicate<FormatException>(
-            (e) => e is FormatException && e.message == 'area code cannot start with zero')));
-  }, skip: true);
+    test('invalid if area code starts with 0', () {
+      expect(
+          () => phoneNumber.clean('(023) 456-7890'),
+          throwsA(predicate<FormatException>(
+              (e) => e is FormatException && e.message == 'area code cannot start with zero')));
+    }, skip: true);
 
-  test('invalid if area code starts with 1', () {
-    expect(
-        () => phoneNumber.clean('(123) 456-7890'),
-        throwsA(
-            predicate<FormatException>((e) => e is FormatException && e.message == 'area code cannot start with one')));
-  }, skip: true);
-}
+    test('invalid if area code starts with 1', () {
+      expect(
+          () => phoneNumber.clean('(123) 456-7890'),
+          throwsA(predicate<FormatException>(
+              (e) => e is FormatException && e.message == 'area code cannot start with one')));
+    }, skip: true);
 
-void exchangeCodeTests() {
-  test('invalid if exchange code starts with 0', () {
-    expect(
-        () => phoneNumber.clean('(223) 056-7890'),
-        throwsA(predicate<FormatException>(
-            (e) => e is FormatException && e.message == 'exchange code cannot start with zero')));
-  }, skip: true);
+    test('invalid if exchange code starts with 0', () {
+      expect(
+          () => phoneNumber.clean('(223) 056-7890'),
+          throwsA(predicate<FormatException>(
+              (e) => e is FormatException && e.message == 'exchange code cannot start with zero')));
+    }, skip: true);
 
-  test('invalid if exchange code starts with 1', () {
-    expect(
-        () => phoneNumber.clean('(223) 156-7890'),
-        throwsA(predicate<FormatException>(
-            (e) => e is FormatException && e.message == 'exchange code cannot start with one')));
-  }, skip: true);
+    test('invalid if exchange code starts with 1', () {
+      expect(
+          () => phoneNumber.clean('(223) 156-7890'),
+          throwsA(predicate<FormatException>(
+              (e) => e is FormatException && e.message == 'exchange code cannot start with one')));
+    }, skip: true);
 
-  test('invalid if area code starts with 0 on valid 11-digit number', () {
-    expect(
-        () => phoneNumber.clean('1 (023) 456-7890'),
-        throwsA(predicate<FormatException>(
-            (e) => e is FormatException && e.message == 'area code cannot start with zero')));
-  }, skip: true);
+    test('invalid if area code starts with 0 on valid 11-digit number', () {
+      expect(
+          () => phoneNumber.clean('1 (023) 456-7890'),
+          throwsA(predicate<FormatException>(
+              (e) => e is FormatException && e.message == 'area code cannot start with zero')));
+    }, skip: true);
 
-  test('invalid if area code starts with 1 on valid 11-digit number', () {
-    expect(
-        () => phoneNumber.clean('1 (123) 456-7890'),
-        throwsA(
-            predicate<FormatException>((e) => e is FormatException && e.message == 'area code cannot start with one')));
-  }, skip: true);
+    test('invalid if area code starts with 1 on valid 11-digit number', () {
+      expect(
+          () => phoneNumber.clean('1 (123) 456-7890'),
+          throwsA(predicate<FormatException>(
+              (e) => e is FormatException && e.message == 'area code cannot start with one')));
+    }, skip: true);
 
-  test('invalid if exchange code starts with 0 on valid 11-digit number', () {
-    expect(
-        () => phoneNumber.clean('1 (223) 056-7890'),
-        throwsA(predicate<FormatException>(
-            (e) => e is FormatException && e.message == 'exchange code cannot start with zero')));
-  }, skip: true);
+    test('invalid if exchange code starts with 0 on valid 11-digit number', () {
+      expect(
+          () => phoneNumber.clean('1 (223) 056-7890'),
+          throwsA(predicate<FormatException>(
+              (e) => e is FormatException && e.message == 'exchange code cannot start with zero')));
+    }, skip: true);
 
-  test('invalid if exchange code starts with 1 on valid 11-digit number', () {
-    expect(
-        () => phoneNumber.clean('1 (223) 156-7890'),
-        throwsA(predicate<FormatException>(
-            (e) => e is FormatException && e.message == 'exchange code cannot start with one')));
-  }, skip: true);
+    test('invalid if exchange code starts with 1 on valid 11-digit number', () {
+      expect(
+          () => phoneNumber.clean('1 (223) 156-7890'),
+          throwsA(predicate<FormatException>(
+              (e) => e is FormatException && e.message == 'exchange code cannot start with one')));
+    }, skip: true);
+  });
 }

--- a/exercises/practice/phone-number/test/phone_number_test.dart
+++ b/exercises/practice/phone-number/test/phone_number_test.dart
@@ -22,16 +22,28 @@ void main() {
 
     test('invalid when 9 digits', () {
       expect(
-          () => phoneNumber.clean('123456789'),
-          throwsA(
-              predicate<FormatException>((e) => e is FormatException && e.message == 'incorrect number of digits')));
+        () => phoneNumber.clean('123456789'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            'incorrect number of digits',
+          ),
+        ),
+      );
     }, skip: true);
 
     test('invalid when 11 digits does not start with a 1', () {
       expect(
-          () => phoneNumber.clean('22234567890'),
-          throwsA(
-              predicate<FormatException>((e) => e is FormatException && e.message == '11 digits must start with 1')));
+        () => phoneNumber.clean('22234567890'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            '11 digits must start with 1',
+          ),
+        ),
+      );
     }, skip: true);
 
     test('valid when 11 digits and starting with 1', () {
@@ -45,76 +57,146 @@ void main() {
     }, skip: true);
 
     test('invalid when more than 11 digits', () {
-      expect(() => phoneNumber.clean('321234567890'),
-          throwsA(predicate<FormatException>((e) => e is FormatException && e.message == 'more than 11 digits')));
+      expect(
+        () => phoneNumber.clean('321234567890'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            'more than 11 digits',
+          ),
+        ),
+      );
     }, skip: true);
 
     test('invalid with letters', () {
-      expect(() => phoneNumber.clean('523-abc-7890'),
-          throwsA(predicate<FormatException>((e) => e is FormatException && e.message == 'letters not permitted')));
+      expect(
+        () => phoneNumber.clean('523-abc-7890'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            'letters not permitted',
+          ),
+        ),
+      );
     }, skip: true);
 
     test('invalid with punctuations', () {
       expect(
-          () => phoneNumber.clean('523-@:!-7890'),
-          throwsA(
-              predicate<FormatException>((e) => e is FormatException && e.message == 'punctuations not permitted')));
+        () => phoneNumber.clean('523-@:!-7890'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            'punctuations not permitted',
+          ),
+        ),
+      );
     }, skip: true);
 
     test('invalid if area code starts with 0', () {
       expect(
-          () => phoneNumber.clean('(023) 456-7890'),
-          throwsA(predicate<FormatException>(
-              (e) => e is FormatException && e.message == 'area code cannot start with zero')));
+        () => phoneNumber.clean('(023) 456-7890'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            'area code cannot start with zero',
+          ),
+        ),
+      );
     }, skip: true);
 
     test('invalid if area code starts with 1', () {
       expect(
-          () => phoneNumber.clean('(123) 456-7890'),
-          throwsA(predicate<FormatException>(
-              (e) => e is FormatException && e.message == 'area code cannot start with one')));
+        () => phoneNumber.clean('(123) 456-7890'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            'area code cannot start with one',
+          ),
+        ),
+      );
     }, skip: true);
 
     test('invalid if exchange code starts with 0', () {
       expect(
-          () => phoneNumber.clean('(223) 056-7890'),
-          throwsA(predicate<FormatException>(
-              (e) => e is FormatException && e.message == 'exchange code cannot start with zero')));
+        () => phoneNumber.clean('(223) 056-7890'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            'exchange code cannot start with zero',
+          ),
+        ),
+      );
     }, skip: true);
 
     test('invalid if exchange code starts with 1', () {
       expect(
-          () => phoneNumber.clean('(223) 156-7890'),
-          throwsA(predicate<FormatException>(
-              (e) => e is FormatException && e.message == 'exchange code cannot start with one')));
+        () => phoneNumber.clean('(223) 156-7890'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            'exchange code cannot start with one',
+          ),
+        ),
+      );
     }, skip: true);
 
     test('invalid if area code starts with 0 on valid 11-digit number', () {
       expect(
-          () => phoneNumber.clean('1 (023) 456-7890'),
-          throwsA(predicate<FormatException>(
-              (e) => e is FormatException && e.message == 'area code cannot start with zero')));
+        () => phoneNumber.clean('1 (023) 456-7890'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            'area code cannot start with zero',
+          ),
+        ),
+      );
     }, skip: true);
 
     test('invalid if area code starts with 1 on valid 11-digit number', () {
       expect(
-          () => phoneNumber.clean('1 (123) 456-7890'),
-          throwsA(predicate<FormatException>(
-              (e) => e is FormatException && e.message == 'area code cannot start with one')));
+        () => phoneNumber.clean('1 (123) 456-7890'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            'area code cannot start with one',
+          ),
+        ),
+      );
     }, skip: true);
 
     test('invalid if exchange code starts with 0 on valid 11-digit number', () {
       expect(
-          () => phoneNumber.clean('1 (223) 056-7890'),
-          throwsA(predicate<FormatException>(
-              (e) => e is FormatException && e.message == 'exchange code cannot start with zero')));
+        () => phoneNumber.clean('1 (223) 056-7890'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            'exchange code cannot start with zero',
+          ),
+        ),
+      );
     }, skip: true);
 
     test('invalid if exchange code starts with 1 on valid 11-digit number', () {
       expect(
-          () => phoneNumber.clean('1 (223) 156-7890'),
-          throwsA(predicate<FormatException>(
-              (e) => e is FormatException && e.message == 'exchange code cannot start with one')));
+        () => phoneNumber.clean('1 (223) 156-7890'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            'exchange code cannot start with one',
+          ),
+        ),
+      );
     }, skip: true);
   });
 }

--- a/exercises/practice/phone-number/test/phone_number_test.dart
+++ b/exercises/practice/phone-number/test/phone_number_test.dart
@@ -50,13 +50,13 @@ void main() {
     }, skip: true);
 
     test('invalid with letters', () {
-      expect(() => phoneNumber.clean('123-abc-7890'),
+      expect(() => phoneNumber.clean('523-abc-7890'),
           throwsA(predicate<FormatException>((e) => e is FormatException && e.message == 'letters not permitted')));
     }, skip: true);
 
     test('invalid with punctuations', () {
       expect(
-          () => phoneNumber.clean('123-@:!-7890'),
+          () => phoneNumber.clean('523-@:!-7890'),
           throwsA(
               predicate<FormatException>((e) => e is FormatException && e.message == 'punctuations not permitted')));
     }, skip: true);


### PR DESCRIPTION
The first commit regenerates the test suite. This removed nesting, which I believe was done manually.

The second commit syncs with problem-specifications, updating the instructions and reimplementing two tests to get less ambiguous error situations.