### PR TITLE
Sync armstrong-numbers with problem-specifications

### DIFF
--- a/config.json
+++ b/config.json
@@ -132,7 +132,7 @@
         "uuid": "4f650701-9568-4d95-9f72-be4bde2c90ec",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1,
+        "difficulty": 2,
         "topics": [
           "equality",
           "integers",

--- a/exercises/practice/armstrong-numbers/.docs/instructions.md
+++ b/exercises/practice/armstrong-numbers/.docs/instructions.md
@@ -1,6 +1,6 @@
 # Instructions
 
-An [Armstrong number](https://en.wikipedia.org/wiki/Narcissistic_number) is a number that is the sum of its own digits each raised to the power of the number of digits.
+An [Armstrong number][armstrong-number] is a number that is the sum of its own digits each raised to the power of the number of digits.
 
 For example:
 
@@ -10,3 +10,5 @@ For example:
 - 154 is *not* an Armstrong number, because: `154 != 1^3 + 5^3 + 4^3 = 1 + 125 + 64 = 190`
 
 Write some code to determine whether a number is an Armstrong number.
+
+[armstrong-number]: https://en.wikipedia.org/wiki/Narcissistic_number

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -3,7 +3,8 @@
     "Stargator"
   ],
   "contributors": [
-    "amscotti"
+    "amscotti",
+    "kytrinyx"
   ],
   "files": {
     "solution": [
@@ -16,7 +17,7 @@
       ".meta/lib/example.dart"
     ]
   },
-  "blurb": "Determine if a number is an Armstrong number",
+  "blurb": "Determine if a number is an Armstrong number.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Narcissistic_number"
 }

--- a/exercises/practice/armstrong-numbers/.meta/lib/example.dart
+++ b/exercises/practice/armstrong-numbers/.meta/lib/example.dart
@@ -3,17 +3,16 @@ import 'dart:math' show pow;
 class ArmstrongNumbers {
   /// The parameters and variables within the method that are set to final in order to prevent the accidentally modification of the value.
   /// As those variables are not needed to be changed.
-  bool isArmstrongNumber(final num input) {
-    final String numberAsString = input.toString();
-    final int numOfDigits = numberAsString.length;
-    num sum = 0;
+  bool isArmstrongNumber(final String input) {
+    final numOfDigits = input.length;
+    var sum = BigInt.from(0);
 
-    for (int count = 0; count < numOfDigits; count++) {
-      final String digitAsString = numberAsString.substring(count, count + 1);
-      final int digit = int.parse(digitAsString);
-      sum += pow(digit, numOfDigits);
+    for (var count = 0; count < numOfDigits; count++) {
+      final digitAsString = input.substring(count, count + 1);
+      final digit = BigInt.parse(digitAsString);
+      sum += digit.pow(numOfDigits);
     }
 
-    return input == sum;
+    return input == sum.toString();
   }
 }

--- a/exercises/practice/armstrong-numbers/.meta/lib/example.dart
+++ b/exercises/practice/armstrong-numbers/.meta/lib/example.dart
@@ -1,5 +1,3 @@
-import 'dart:math' show pow;
-
 class ArmstrongNumbers {
   /// The parameters and variables within the method that are set to final in order to prevent the accidentally modification of the value.
   /// As those variables are not needed to be changed.

--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -1,30 +1,43 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [c1ed103c-258d-45b2-be73-d8c6d9580c7b]
 description = "Zero is an Armstrong number"
 
 [579e8f03-9659-4b85-a1a2-d64350f6b17a]
-description = "Single digit numbers are Armstrong numbers"
+description = "Single-digit numbers are Armstrong numbers"
 
 [2d6db9dc-5bf8-4976-a90b-b2c2b9feba60]
-description = "There are no 2 digit Armstrong numbers"
+description = "There are no two-digit Armstrong numbers"
 
 [509c087f-e327-4113-a7d2-26a4e9d18283]
-description = "Three digit number that is an Armstrong number"
+description = "Three-digit number that is an Armstrong number"
 
 [7154547d-c2ce-468d-b214-4cb953b870cf]
-description = "Three digit number that is not an Armstrong number"
+description = "Three-digit number that is not an Armstrong number"
 
 [6bac5b7b-42e9-4ecb-a8b0-4832229aa103]
-description = "Four digit number that is an Armstrong number"
+description = "Four-digit number that is an Armstrong number"
 
 [eed4b331-af80-45b5-a80b-19c9ea444b2e]
-description = "Four digit number that is not an Armstrong number"
+description = "Four-digit number that is not an Armstrong number"
 
 [f971ced7-8d68-4758-aea1-d4194900b864]
-description = "Seven digit number that is an Armstrong number"
+description = "Seven-digit number that is an Armstrong number"
 
 [7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18]
-description = "Seven digit number that is not an Armstrong number"
+description = "Seven-digit number that is not an Armstrong number"
+
+[5ee2fdf8-334e-4a46-bb8d-e5c19c02c148]
+description = "Armstrong number containing seven zeroes"
+
+[12ffbf10-307a-434e-b4ad-c925680e1dd4]
+description = "The largest and last Armstrong number"

--- a/exercises/practice/armstrong-numbers/test/armstrong_numbers_test.dart
+++ b/exercises/practice/armstrong-numbers/test/armstrong_numbers_test.dart
@@ -6,48 +6,58 @@ void main() {
 
   group('ArmstrongNumbers', () {
     test('Zero is an Armstrong number', () {
-      final result = armstrongNumbers.isArmstrongNumber(0);
+      final result = armstrongNumbers.isArmstrongNumber('0');
       expect(result, equals(true));
     }, skip: false);
 
     test('Single-digit numbers are Armstrong numbers', () {
-      final result = armstrongNumbers.isArmstrongNumber(5);
+      final result = armstrongNumbers.isArmstrongNumber('5');
       expect(result, equals(true));
     }, skip: true);
 
     test('There are no two-digit Armstrong numbers', () {
-      final result = armstrongNumbers.isArmstrongNumber(10);
+      final result = armstrongNumbers.isArmstrongNumber('10');
       expect(result, equals(false));
     }, skip: true);
 
     test('Three-digit number that is an Armstrong number', () {
-      final result = armstrongNumbers.isArmstrongNumber(153);
+      final result = armstrongNumbers.isArmstrongNumber('153');
       expect(result, equals(true));
     }, skip: true);
 
     test('Three-digit number that is not an Armstrong number', () {
-      final result = armstrongNumbers.isArmstrongNumber(100);
+      final result = armstrongNumbers.isArmstrongNumber('100');
       expect(result, equals(false));
     }, skip: true);
 
     test('Four-digit number that is an Armstrong number', () {
-      final result = armstrongNumbers.isArmstrongNumber(9474);
+      final result = armstrongNumbers.isArmstrongNumber('9474');
       expect(result, equals(true));
     }, skip: true);
 
     test('Four-digit number that is not an Armstrong number', () {
-      final result = armstrongNumbers.isArmstrongNumber(9475);
+      final result = armstrongNumbers.isArmstrongNumber('9475');
       expect(result, equals(false));
     }, skip: true);
 
     test('Seven-digit number that is an Armstrong number', () {
-      final result = armstrongNumbers.isArmstrongNumber(9926315);
+      final result = armstrongNumbers.isArmstrongNumber('9926315');
       expect(result, equals(true));
     }, skip: true);
 
     test('Seven-digit number that is not an Armstrong number', () {
-      final result = armstrongNumbers.isArmstrongNumber(9926314);
+      final result = armstrongNumbers.isArmstrongNumber('9926314');
       expect(result, equals(false));
+    }, skip: true);
+
+    test('Armstrong number containing seven zeroes', () {
+      final result = armstrongNumbers.isArmstrongNumber('186709961001538790100634132976990');
+      expect(result, equals(true));
+    }, skip: true);
+
+    test('The largest and last Armstrong number', () {
+      final result = armstrongNumbers.isArmstrongNumber('115132219018763992565095597973971522401');
+      expect(result, equals(true));
     }, skip: true);
   });
 }

--- a/exercises/practice/armstrong-numbers/test/armstrong_numbers_test.dart
+++ b/exercises/practice/armstrong-numbers/test/armstrong_numbers_test.dart
@@ -1,52 +1,52 @@
 import 'package:armstrong_numbers/armstrong_numbers.dart';
 import 'package:test/test.dart';
 
-final armstrongNumbers = ArmstrongNumbers();
-
 void main() {
+  final armstrongNumbers = ArmstrongNumbers();
+
   group('ArmstrongNumbers', () {
     test('Zero is an Armstrong number', () {
-      final bool result = armstrongNumbers.isArmstrongNumber(0);
+      final result = armstrongNumbers.isArmstrongNumber(0);
       expect(result, equals(true));
     }, skip: false);
 
-    test('Single digit numbers are Armstrong numbers', () {
-      final bool result = armstrongNumbers.isArmstrongNumber(5);
+    test('Single-digit numbers are Armstrong numbers', () {
+      final result = armstrongNumbers.isArmstrongNumber(5);
       expect(result, equals(true));
     }, skip: true);
 
-    test('There are no 2 digit Armstrong numbers', () {
-      final bool result = armstrongNumbers.isArmstrongNumber(10);
+    test('There are no two-digit Armstrong numbers', () {
+      final result = armstrongNumbers.isArmstrongNumber(10);
       expect(result, equals(false));
     }, skip: true);
 
-    test('Three digit number that is an Armstrong number', () {
-      final bool result = armstrongNumbers.isArmstrongNumber(153);
+    test('Three-digit number that is an Armstrong number', () {
+      final result = armstrongNumbers.isArmstrongNumber(153);
       expect(result, equals(true));
     }, skip: true);
 
-    test('Three digit number that is not an Armstrong number', () {
-      final bool result = armstrongNumbers.isArmstrongNumber(100);
+    test('Three-digit number that is not an Armstrong number', () {
+      final result = armstrongNumbers.isArmstrongNumber(100);
       expect(result, equals(false));
     }, skip: true);
 
-    test('Four digit number that is an Armstrong number', () {
-      final bool result = armstrongNumbers.isArmstrongNumber(9474);
+    test('Four-digit number that is an Armstrong number', () {
+      final result = armstrongNumbers.isArmstrongNumber(9474);
       expect(result, equals(true));
     }, skip: true);
 
-    test('Four digit number that is not an Armstrong number', () {
-      final bool result = armstrongNumbers.isArmstrongNumber(9475);
+    test('Four-digit number that is not an Armstrong number', () {
+      final result = armstrongNumbers.isArmstrongNumber(9475);
       expect(result, equals(false));
     }, skip: true);
 
-    test('Seven digit number that is an Armstrong number', () {
-      final bool result = armstrongNumbers.isArmstrongNumber(9926315);
+    test('Seven-digit number that is an Armstrong number', () {
+      final result = armstrongNumbers.isArmstrongNumber(9926315);
       expect(result, equals(true));
     }, skip: true);
 
-    test('Seven digit number that is not an Armstrong number', () {
-      final bool result = armstrongNumbers.isArmstrongNumber(9926314);
+    test('Seven-digit number that is not an Armstrong number', () {
+      final result = armstrongNumbers.isArmstrongNumber(9926314);
       expect(result, equals(false));
     }, skip: true);
   });


### PR DESCRIPTION
This updates the instructions and brings in two new tests,
both of which handle very big numbers.

In order to support these new tests, the example solution
has been updated to use BigInt.

Closes #434