### PR TITLE
Simplify assignment in two-fer

### DIFF
--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -3,7 +3,8 @@
     "amscotti"
   ],
   "contributors": [
-    "Stargator"
+    "Stargator",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/two-fer/test/two_fer_test.dart
+++ b/exercises/practice/two-fer/test/two_fer_test.dart
@@ -4,17 +4,17 @@ import 'package:two_fer/two_fer.dart';
 void main() {
   group('TwoFer', () {
     test('no name given', () {
-      final String result = twoFer();
+      final result = twoFer();
       expect(result, equals('One for you, one for me.'));
     }, skip: false);
 
     test('a name given', () {
-      final String result = twoFer('Alice');
+      final result = twoFer('Alice');
       expect(result, equals('One for Alice, one for me.'));
     }, skip: true);
 
     test('another name given', () {
-      final String result = twoFer('Bob');
+      final result = twoFer('Bob');
       expect(result, equals('One for Bob, one for me.'));
     }, skip: true);
   });


### PR DESCRIPTION
Remove the explicit type definition in two-fer test suite,
allowing the type to be inferred.
