### PR TITLE
Simplify assignments in scrabble-score

### DIFF
--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -3,7 +3,8 @@
     "jvarness"
   ],
   "contributors": [
-    "Stargator"
+    "Stargator",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/scrabble-score/test/scrabble_score_test.dart
+++ b/exercises/practice/scrabble-score/test/scrabble_score_test.dart
@@ -4,57 +4,57 @@ import 'package:test/test.dart';
 void main() {
   group('ScrabbleScore', () {
     test('lowercase letter', () {
-      final int result = score('a');
+      final result = score('a');
       expect(result, equals(1));
     }, skip: false);
 
     test('uppercase letter', () {
-      final int result = score('A');
+      final result = score('A');
       expect(result, equals(1));
     }, skip: true);
 
     test('valuable letter', () {
-      final int result = score('f');
+      final result = score('f');
       expect(result, equals(4));
     }, skip: true);
 
     test('short word', () {
-      final int result = score('at');
+      final result = score('at');
       expect(result, equals(2));
     }, skip: true);
 
     test('short, valuable word', () {
-      final int result = score('zoo');
+      final result = score('zoo');
       expect(result, equals(12));
     }, skip: true);
 
     test('medium word', () {
-      final int result = score('street');
+      final result = score('street');
       expect(result, equals(6));
     }, skip: true);
 
     test('medium, valuable word', () {
-      final int result = score('quirky');
+      final result = score('quirky');
       expect(result, equals(22));
     }, skip: true);
 
     test('long, mixed-case word', () {
-      final int result = score('OxyphenButazone');
+      final result = score('OxyphenButazone');
       expect(result, equals(41));
     }, skip: true);
 
     test('english-like word', () {
-      final int result = score('pinata');
+      final result = score('pinata');
       expect(result, equals(8));
     }, skip: true);
 
     test('empty input', () {
-      final int result = score('');
+      final result = score('');
       expect(result, equals(0));
     }, skip: true);
 
     test('entire alphabet available', () {
-      final int result = score('abcdefghijklmnopqrstuvwxyz');
+      final result = score('abcdefghijklmnopqrstuvwxyz');
       expect(result, equals(87));
     }, skip: true);
   });


### PR DESCRIPTION
This remove the explicit type definition in the
variable assignment in the scrabble-score test suite
allowing the types to be inferred.
