### PR TITLE
Simplify assignment in difference-of-squares

### DIFF
--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -3,7 +3,8 @@
     "SuperPaintman"
   ],
   "contributors": [
-    "Stargator"
+    "Stargator",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/difference-of-squares/test/difference_of_squares_test.dart
+++ b/exercises/practice/difference-of-squares/test/difference_of_squares_test.dart
@@ -4,56 +4,60 @@ import 'package:test/test.dart';
 final differenceOfSquares = DifferenceOfSquares();
 
 void main() {
-  group('DifferenceOfSquares', () {
-    group('Square the sum of the numbers up to the given number', () {
-      test('square of sum 1', () {
-        final int result = differenceOfSquares.squareOfSum(1);
-        expect(result, equals(1));
-      }, skip: false);
+  group('DifferenceOfSquares: Square the sum of the numbers up to the given number - ',
+      squareTheSumOfTheNumbersUpToTheGivenNumber);
+  group('DifferenceOfSquares: Sum the squares of the numbers up to the given number - ',
+      sumTheSquaresOfTheNumbersUpToTheGivenNumber);
+  group('DifferenceOfSquares: Subtract sum of squares from square of sums - ', subtractSumOfSquaresFromSquareOfSums);
+}
 
-      test('square of sum 5', () {
-        final int result = differenceOfSquares.squareOfSum(5);
-        expect(result, equals(225));
-      }, skip: true);
+void squareTheSumOfTheNumbersUpToTheGivenNumber() {
+  test('square of sum 1', () {
+    final result = differenceOfSquares.squareOfSum(1);
+    expect(result, equals(1));
+  }, skip: false);
 
-      test('square of sum 100', () {
-        final int result = differenceOfSquares.squareOfSum(100);
-        expect(result, equals(25502500));
-      }, skip: true);
-    });
+  test('square of sum 5', () {
+    final result = differenceOfSquares.squareOfSum(5);
+    expect(result, equals(225));
+  }, skip: true);
 
-    group('Sum the squares of the numbers up to the given number', () {
-      test('sum of squares 1', () {
-        final int result = differenceOfSquares.sumOfSquares(1);
-        expect(result, equals(1));
-      }, skip: true);
+  test('square of sum 100', () {
+    final result = differenceOfSquares.squareOfSum(100);
+    expect(result, equals(25502500));
+  }, skip: true);
+}
 
-      test('sum of squares 5', () {
-        final int result = differenceOfSquares.sumOfSquares(5);
-        expect(result, equals(55));
-      }, skip: true);
+void sumTheSquaresOfTheNumbersUpToTheGivenNumber() {
+  test('sum of squares 1', () {
+    final result = differenceOfSquares.sumOfSquares(1);
+    expect(result, equals(1));
+  }, skip: true);
 
-      test('sum of squares 100', () {
-        final int result = differenceOfSquares.sumOfSquares(100);
-        expect(result, equals(338350));
-      }, skip: true);
-    });
+  test('sum of squares 5', () {
+    final result = differenceOfSquares.sumOfSquares(5);
+    expect(result, equals(55));
+  }, skip: true);
 
-    group('Subtract sum of squares from square of sums', () {
-      test('difference of squares 1', () {
-        final int result = differenceOfSquares.differenceOfSquares(1);
-        expect(result, equals(0));
-      }, skip: true);
+  test('sum of squares 100', () {
+    final result = differenceOfSquares.sumOfSquares(100);
+    expect(result, equals(338350));
+  }, skip: true);
+}
 
-      test('difference of squares 5', () {
-        final int result = differenceOfSquares.differenceOfSquares(5);
-        expect(result, equals(170));
-      }, skip: true);
+void subtractSumOfSquaresFromSquareOfSums() {
+  test('difference of squares 1', () {
+    final result = differenceOfSquares.differenceOfSquares(1);
+    expect(result, equals(0));
+  }, skip: true);
 
-      test('difference of squares 100', () {
-        final int result = differenceOfSquares.differenceOfSquares(100);
-        expect(result, equals(25164150));
-      }, skip: true);
-    });
-  });
+  test('difference of squares 5', () {
+    final result = differenceOfSquares.differenceOfSquares(5);
+    expect(result, equals(170));
+  }, skip: true);
+
+  test('difference of squares 100', () {
+    final result = differenceOfSquares.differenceOfSquares(100);
+    expect(result, equals(25164150));
+  }, skip: true);
 }


### PR DESCRIPTION
This allows types to be inferred in the test suite
for difference-of-squares instead of explicitly defining
them.

It also removes a level of nesting by moving the group definitions
out of main.
