### PR TITLE
Simplify assignment in diamond

### DIFF
--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -4,7 +4,8 @@
   ],
   "contributors": [
     "Stargator",
-    "Zureka"
+    "Zureka",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/diamond/test/diamond_test.dart
+++ b/exercises/practice/diamond/test/diamond_test.dart
@@ -1,120 +1,87 @@
 import 'package:diamond/diamond.dart';
 import 'package:test/test.dart';
 
-final diamond = Diamond();
-
 void main() {
+  final diamond = Diamond();
+
   group('Diamond', () {
-    test('Degenerate case with a single "A" row', () {
-      final List<String> result = diamond.rows('A');
-      expect(
-        result,
-        equals([
-          'A',
-        ]),
-      );
+    test('Degenerate case with a single \'A\' row', () {
+      final result = diamond.rows('A');
+      expect(result, equals(<String>['A']));
     }, skip: false);
 
     test('Degenerate case with no row containing 3 distinct groups of spaces', () {
-      final List<String> result = diamond.rows('B');
-      expect(
-        result,
-        equals([
-          ' A ',
-          'B B',
-          ' A ',
-        ]),
-      );
+      final result = diamond.rows('B');
+      expect(result, equals(<String>[' A ', 'B B', ' A ']));
     }, skip: true);
 
     test('Smallest non-degenerate case with odd diamond side length', () {
-      final List<String> result = diamond.rows('C');
-      expect(
-        result,
-        equals([
-          '  A  ',
-          ' B B ',
-          'C   C',
-          ' B B ',
-          '  A  ',
-        ]),
-      );
+      final result = diamond.rows('C');
+      expect(result, equals(<String>['  A  ', ' B B ', 'C   C', ' B B ', '  A  ']));
     }, skip: true);
 
     test('Smallest non-degenerate case with even diamond side length', () {
-      final List<String> result = diamond.rows('D');
-      expect(
-        result,
-        equals([
-          '   A   ',
-          '  B B  ',
-          ' C   C ',
-          'D     D',
-          ' C   C ',
-          '  B B  ',
-          '   A   ',
-        ]),
-      );
+      final result = diamond.rows('D');
+      expect(result, equals(<String>['   A   ', '  B B  ', ' C   C ', 'D     D', ' C   C ', '  B B  ', '   A   ']));
     }, skip: true);
 
     test('Largest possible diamond', () {
-      final List<String> result = diamond.rows('Z');
+      final result = diamond.rows('Z');
       expect(
-        result,
-        equals([
-          '                         A                         ',
-          '                        B B                        ',
-          '                       C   C                       ',
-          '                      D     D                      ',
-          '                     E       E                     ',
-          '                    F         F                    ',
-          '                   G           G                   ',
-          '                  H             H                  ',
-          '                 I               I                 ',
-          '                J                 J                ',
-          '               K                   K               ',
-          '              L                     L              ',
-          '             M                       M             ',
-          '            N                         N            ',
-          '           O                           O           ',
-          '          P                             P          ',
-          '         Q                               Q         ',
-          '        R                                 R        ',
-          '       S                                   S       ',
-          '      T                                     T      ',
-          '     U                                       U     ',
-          '    V                                         V    ',
-          '   W                                           W   ',
-          '  X                                             X  ',
-          ' Y                                               Y ',
-          'Z                                                 Z',
-          ' Y                                               Y ',
-          '  X                                             X  ',
-          '   W                                           W   ',
-          '    V                                         V    ',
-          '     U                                       U     ',
-          '      T                                     T      ',
-          '       S                                   S       ',
-          '        R                                 R        ',
-          '         Q                               Q         ',
-          '          P                             P          ',
-          '           O                           O           ',
-          '            N                         N            ',
-          '             M                       M             ',
-          '              L                     L              ',
-          '               K                   K               ',
-          '                J                 J                ',
-          '                 I               I                 ',
-          '                  H             H                  ',
-          '                   G           G                   ',
-          '                    F         F                    ',
-          '                     E       E                     ',
-          '                      D     D                      ',
-          '                       C   C                       ',
-          '                        B B                        ',
-          '                         A                         ',
-        ]),
-      );
+          result,
+          equals(<String>[
+            '                         A                         ',
+            '                        B B                        ',
+            '                       C   C                       ',
+            '                      D     D                      ',
+            '                     E       E                     ',
+            '                    F         F                    ',
+            '                   G           G                   ',
+            '                  H             H                  ',
+            '                 I               I                 ',
+            '                J                 J                ',
+            '               K                   K               ',
+            '              L                     L              ',
+            '             M                       M             ',
+            '            N                         N            ',
+            '           O                           O           ',
+            '          P                             P          ',
+            '         Q                               Q         ',
+            '        R                                 R        ',
+            '       S                                   S       ',
+            '      T                                     T      ',
+            '     U                                       U     ',
+            '    V                                         V    ',
+            '   W                                           W   ',
+            '  X                                             X  ',
+            ' Y                                               Y ',
+            'Z                                                 Z',
+            ' Y                                               Y ',
+            '  X                                             X  ',
+            '   W                                           W   ',
+            '    V                                         V    ',
+            '     U                                       U     ',
+            '      T                                     T      ',
+            '       S                                   S       ',
+            '        R                                 R        ',
+            '         Q                               Q         ',
+            '          P                             P          ',
+            '           O                           O           ',
+            '            N                         N            ',
+            '             M                       M             ',
+            '              L                     L              ',
+            '               K                   K               ',
+            '                J                 J                ',
+            '                 I               I                 ',
+            '                  H             H                  ',
+            '                   G           G                   ',
+            '                    F         F                    ',
+            '                     E       E                     ',
+            '                      D     D                      ',
+            '                       C   C                       ',
+            '                        B B                        ',
+            '                         A                         '
+          ]));
     }, skip: true);
   });
 }

--- a/exercises/practice/diamond/test/diamond_test.dart
+++ b/exercises/practice/diamond/test/diamond_test.dart
@@ -7,22 +7,50 @@ void main() {
   group('Diamond', () {
     test('Degenerate case with a single \'A\' row', () {
       final result = diamond.rows('A');
-      expect(result, equals(<String>['A']));
+      expect(
+          result,
+          equals(<String>[
+            'A',
+          ]));
     }, skip: false);
 
     test('Degenerate case with no row containing 3 distinct groups of spaces', () {
       final result = diamond.rows('B');
-      expect(result, equals(<String>[' A ', 'B B', ' A ']));
+      expect(
+          result,
+          equals(<String>[
+            ' A ',
+            'B B',
+            ' A ',
+          ]));
     }, skip: true);
 
     test('Smallest non-degenerate case with odd diamond side length', () {
       final result = diamond.rows('C');
-      expect(result, equals(<String>['  A  ', ' B B ', 'C   C', ' B B ', '  A  ']));
+      expect(
+          result,
+          equals(<String>[
+            '  A  ',
+            ' B B ',
+            'C   C',
+            ' B B ',
+            '  A  ',
+          ]));
     }, skip: true);
 
     test('Smallest non-degenerate case with even diamond side length', () {
       final result = diamond.rows('D');
-      expect(result, equals(<String>['   A   ', '  B B  ', ' C   C ', 'D     D', ' C   C ', '  B B  ', '   A   ']));
+      expect(
+          result,
+          equals(<String>[
+            '   A   ',
+            '  B B  ',
+            ' C   C ',
+            'D     D',
+            ' C   C ',
+            '  B B  ',
+            '   A   ',
+          ]));
     }, skip: true);
 
     test('Largest possible diamond', () {
@@ -80,7 +108,7 @@ void main() {
             '                      D     D                      ',
             '                       C   C                       ',
             '                        B B                        ',
-            '                         A                         '
+            '                         A                         ',
           ]));
     }, skip: true);
   });


### PR DESCRIPTION
This removes the explicit assignments in diamond,
allowing the types to be inferred.
