### PR TITLE
Simplify assignment in rna-transcription

### DIFF
--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -3,7 +3,8 @@
     "SuperPaintman"
   ],
   "contributors": [
-    "Stargator"
+    "Stargator",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/rna-transcription/test/rna_transcription_test.dart
+++ b/exercises/practice/rna-transcription/test/rna_transcription_test.dart
@@ -1,37 +1,37 @@
 import 'package:rna_transcription/rna_transcription.dart';
 import 'package:test/test.dart';
 
-final rnaTranscription = RnaTranscription();
-
 void main() {
+  final rnaTranscription = RnaTranscription();
+
   group('RnaTranscription', () {
     test('Empty RNA sequence', () {
-      final String result = rnaTranscription.toRna('');
+      final result = rnaTranscription.toRna('');
       expect(result, equals(''));
     }, skip: false);
 
     test('RNA complement of cytosine is guanine', () {
-      final String result = rnaTranscription.toRna('C');
+      final result = rnaTranscription.toRna('C');
       expect(result, equals('G'));
     }, skip: true);
 
     test('RNA complement of guanine is cytosine', () {
-      final String result = rnaTranscription.toRna('G');
+      final result = rnaTranscription.toRna('G');
       expect(result, equals('C'));
     }, skip: true);
 
     test('RNA complement of thymine is adenine', () {
-      final String result = rnaTranscription.toRna('T');
+      final result = rnaTranscription.toRna('T');
       expect(result, equals('A'));
     }, skip: true);
 
     test('RNA complement of adenine is uracil', () {
-      final String result = rnaTranscription.toRna('A');
+      final result = rnaTranscription.toRna('A');
       expect(result, equals('U'));
     }, skip: true);
 
     test('RNA complement', () {
-      final String result = rnaTranscription.toRna('ACGTGGTCTTAA');
+      final result = rnaTranscription.toRna('ACGTGGTCTTAA');
       expect(result, equals('UGCACCAGAAUU'));
     }, skip: true);
   });


### PR DESCRIPTION
This removes the explicit assignments in rna-transcription,
allowing the types to be inferred.
