### PR TITLE
Simplify assignment in reverse-string

### DIFF
--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -3,7 +3,8 @@
     "amscotti"
   ],
   "contributors": [
-    "Zureka"
+    "Zureka",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/reverse-string/test/reverse_string_test.dart
+++ b/exercises/practice/reverse-string/test/reverse_string_test.dart
@@ -4,32 +4,32 @@ import 'package:test/test.dart';
 void main() {
   group('ReverseString', () {
     test('an empty string', () {
-      final String result = reverse('');
+      final result = reverse('');
       expect(result, equals(''));
     }, skip: false);
 
     test('a word', () {
-      final String result = reverse('robot');
+      final result = reverse('robot');
       expect(result, equals('tobor'));
     }, skip: true);
 
     test('a capitalized word', () {
-      final String result = reverse('Ramen');
+      final result = reverse('Ramen');
       expect(result, equals('nemaR'));
     }, skip: true);
 
     test('a sentence with punctuation', () {
-      final String result = reverse('I\'m hungry!');
+      final result = reverse('I\'m hungry!');
       expect(result, equals('!yrgnuh m\'I'));
     }, skip: true);
 
     test('a palindrome', () {
-      final String result = reverse('racecar');
+      final result = reverse('racecar');
       expect(result, equals('racecar'));
     }, skip: true);
 
     test('an even-sized word', () {
-      final String result = reverse('drawer');
+      final result = reverse('drawer');
       expect(result, equals('reward'));
     }, skip: true);
   });


### PR DESCRIPTION
This removes the explicit assignments in reverse-string,
allowing the types to be inferred.
