### PR TITLE
Simplify assignment in nth-prime

### DIFF
--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -2,6 +2,9 @@
   "authors": [
     "amscotti"
   ],
+  "contributors": [
+    "kytrinyx"
+  ],
   "files": {
     "solution": [
       "lib/nth_prime.dart"

--- a/exercises/practice/nth-prime/test/nth_prime_test.dart
+++ b/exercises/practice/nth-prime/test/nth_prime_test.dart
@@ -2,33 +2,34 @@ import 'package:nth_prime/nth_prime.dart';
 import 'package:test/test.dart';
 
 void main() {
-  final nthPrime = new NthPrime();
-  final noZerothPrime = predicate((ArgumentError e) => e is ArgumentError && e.message == 'There is no zeroth prime',
-      'an ArgumentError with the message "There is no zeroth prime"');
+  final nthPrime = NthPrime();
 
   group('NthPrime', () {
     test('first prime', () {
-      final int result = nthPrime.prime(1);
+      final result = nthPrime.prime(1);
       expect(result, equals(2));
     }, skip: false);
 
     test('second prime', () {
-      final int result = nthPrime.prime(2);
+      final result = nthPrime.prime(2);
       expect(result, equals(3));
     }, skip: true);
 
     test('sixth prime', () {
-      final int result = nthPrime.prime(6);
+      final result = nthPrime.prime(6);
       expect(result, equals(13));
     }, skip: true);
 
     test('big prime', () {
-      final int result = nthPrime.prime(10001);
+      final result = nthPrime.prime(10001);
       expect(result, equals(104743));
     }, skip: true);
 
     test('there is no zeroth prime', () {
-      expect(() => nthPrime.prime(0), throwsA(noZerothPrime));
+      expect(
+          () => nthPrime.prime(0),
+          throwsA(isA<ArgumentError>()
+              .having((e) => e.toString(), 'message', 'Invalid argument(s): There is no zeroth prime')));
     }, skip: true);
   });
 }


### PR DESCRIPTION
This removes the explicit assignments in nth-prime,
allowing the types to be inferred.
