### PR TITLE
Add dart analyzer to Test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,5 +34,9 @@ jobs:
     - name: Check Stage formatting
       run: dart run bin/check_formatting.dart
 
+    # We can't check the exercises because they will produce errors since the example files have the solution.
+    - name: Analyze Dart code
+      run: dart analyze bin/ lib/ test/
+
     - name: Run tests
       run: dart test


### PR DESCRIPTION
We should include the Dart analyzer when we run the workflow. Though it only checks the bin, lib, and test folders because the exercises can't be checked. The exercises would throw errors because they are referencing a file that does not have the expected implementations.