### PR TITLE
Regenerate minesweeper test suite

### DIFF
--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -3,7 +3,8 @@
     "devkabiir"
   ],
   "contributors": [
-    "sisminnmaw"
+    "sisminnmaw",
+    "kytrinyx"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/minesweeper/.meta/lib/example.dart
+++ b/exercises/practice/minesweeper/.meta/lib/example.dart
@@ -64,7 +64,7 @@ class Minesweeper {
   Row operator [](int index) => _minefield[index];
 
   /// Annoted version of minefield
-  List<String> get annoted => _minefield.map((row) => "$row").toList();
+  List<String> get annotated => _minefield.map((row) => "$row").toList();
 
   /// Number of columns in this minefield
   int get columns => _minefield.isEmpty ? 0 : _minefield.first._cells.length;

--- a/exercises/practice/minesweeper/test/minesweeper_test.dart
+++ b/exercises/practice/minesweeper/test/minesweeper_test.dart
@@ -2,73 +2,65 @@ import 'package:minesweeper/minesweeper.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group("MineSweeper: Simple cases - ", simpleTestCases);
-  group("MineSweeper: Normal cases - ", normalTestCases);
-  group("MineSweeper: Advanced cases - ", advancedTestCases);
-}
+  group('Minesweeper', () {
+    test('no rows', () {
+      final result = Minesweeper(<String>[]).annotated;
+      expect(result, equals(<String>[]));
+    }, skip: false);
 
-void simpleTestCases() {
-  test("no rows", () {
-    List<String> result = new Minesweeper([]).annoted;
-    expect(result, equals(<String>[]));
+    test('no columns', () {
+      final result = Minesweeper(<String>['']).annotated;
+      expect(result, equals(<String>['']));
+    }, skip: true);
+
+    test('no mines', () {
+      final result = Minesweeper(<String>['   ', '   ', '   ']).annotated;
+      expect(result, equals(<String>['   ', '   ', '   ']));
+    }, skip: true);
+
+    test('minefield with only mines', () {
+      final result = Minesweeper(<String>['***', '***', '***']).annotated;
+      expect(result, equals(<String>['***', '***', '***']));
+    }, skip: true);
+
+    test('mine surrounded by spaces', () {
+      final result = Minesweeper(<String>['   ', ' * ', '   ']).annotated;
+      expect(result, equals(<String>['111', '1*1', '111']));
+    }, skip: true);
+
+    test('space surrounded by mines', () {
+      final result = Minesweeper(<String>['***', '* *', '***']).annotated;
+      expect(result, equals(<String>['***', '*8*', '***']));
+    }, skip: true);
+
+    test('horizontal line', () {
+      final result = Minesweeper(<String>[' * * ']).annotated;
+      expect(result, equals(<String>['1*2*1']));
+    }, skip: true);
+
+    test('horizontal line, mines at edges', () {
+      final result = Minesweeper(<String>['*   *']).annotated;
+      expect(result, equals(<String>['*1 1*']));
+    }, skip: true);
+
+    test('vertical line', () {
+      final result = Minesweeper(<String>[' ', '*', ' ', '*', ' ']).annotated;
+      expect(result, equals(<String>['1', '*', '2', '*', '1']));
+    }, skip: true);
+
+    test('vertical line, mines at edges', () {
+      final result = Minesweeper(<String>['*', ' ', ' ', ' ', '*']).annotated;
+      expect(result, equals(<String>['*', '1', ' ', '1', '*']));
+    }, skip: true);
+
+    test('cross', () {
+      final result = Minesweeper(<String>['  *  ', '  *  ', '*****', '  *  ', '  *  ']).annotated;
+      expect(result, equals(<String>[' 2*2 ', '25*52', '*****', '25*52', ' 2*2 ']));
+    }, skip: true);
+
+    test('large minefield', () {
+      final result = Minesweeper(<String>[' *  * ', '  *   ', '    * ', '   * *', ' *  * ', '      ']).annotated;
+      expect(result, equals(<String>['1*22*1', '12*322', ' 123*2', '112*4*', '1*22*2', '111111']));
+    }, skip: true);
   });
-
-  test("no columns", () {
-    List<String> result = new Minesweeper([""]).annoted;
-    expect(result, equals([""]));
-  }, skip: true);
-
-  test("no mines", () {
-    List<String> result = new Minesweeper(["   ", "   ", "   "]).annoted;
-    expect(result, equals(["   ", "   ", "   "]));
-  }, skip: true);
-
-  test("board with only mines", () {
-    List<String> result = new Minesweeper(["***", "***", "***"]).annoted;
-    expect(result, equals(["***", "***", "***"]));
-  }, skip: true);
-}
-
-void normalTestCases() {
-  test("mine surrounded by spaces", () {
-    List<String> result = new Minesweeper(["   ", " * ", "   "]).annoted;
-    expect(result, equals(["111", "1*1", "111"]));
-  }, skip: true);
-
-  test("space surrounded by mines", () {
-    List<String> result = new Minesweeper(["***", "* *", "***"]).annoted;
-    expect(result, equals(["***", "*8*", "***"]));
-  }, skip: true);
-}
-
-void advancedTestCases() {
-  test("horizontal line", () {
-    List<String> result = new Minesweeper([" * * "]).annoted;
-    expect(result, equals(["1*2*1"]));
-  }, skip: true);
-
-  test("horizontal line, mines at edges", () {
-    List<String> result = new Minesweeper(["*   *"]).annoted;
-    expect(result, equals(["*1 1*"]));
-  }, skip: true);
-
-  test("vertical line", () {
-    List<String> result = new Minesweeper([" ", "*", " ", "*", " "]).annoted;
-    expect(result, equals(["1", "*", "2", "*", "1"]));
-  }, skip: true);
-
-  test("vertical line, mines at edges", () {
-    List<String> result = new Minesweeper(["*", " ", " ", " ", "*"]).annoted;
-    expect(result, equals(["*", "1", " ", "1", "*"]));
-  }, skip: true);
-
-  test("cross", () {
-    List<String> result = new Minesweeper(["  *  ", "  *  ", "*****", "  *  ", "  *  "]).annoted;
-    expect(result, equals([" 2*2 ", "25*52", "*****", "25*52", " 2*2 "]));
-  }, skip: true);
-
-  test("large board", () {
-    List<String> result = new Minesweeper([" *  * ", "  *   ", "    * ", "   * *", " *  * ", "      "]).annoted;
-    expect(result, equals(["1*22*1", "12*322", " 123*2", "112*4*", "1*22*2", "111111"]));
-  }, skip: true);
 }


### PR DESCRIPTION
This:
- fixes a typo in a getter name (annoted -> annotated)
- replaces multiple test groups with a single group
- remove explicit type definition when assigning 'result'
- makes the 'result' assignment final
