### PR TITLE
Add stub for new exercise: sum-of-multiples

### DIFF
--- a/config.json
+++ b/config.json
@@ -244,6 +244,14 @@
         ]
       },
       {
+        "uuid": "6b552157-5c08-413e-8667-b9555a1dbba5",
+        "slug": "sum-of-multiples",
+        "name": "Sum of Multiples",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
         "slug": "rna-transcription",
         "name": "RNA Transcription",
         "uuid": "99147c39-e8d3-4166-9215-c47fb4832781",

--- a/exercises/practice/sum-of-multiples/.docs/instructions.md
+++ b/exercises/practice/sum-of-multiples/.docs/instructions.md
@@ -1,0 +1,7 @@
+# Instructions
+
+Given a number, find the sum of all the unique multiples of particular numbers up to but not including that number.
+
+If we list all the natural numbers below 20 that are multiples of 3 or 5, we get 3, 5, 6, 9, 10, 12, 15, and 18.
+
+The sum of these multiples is 78.

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -1,0 +1,20 @@
+{
+  "authors": [],
+  "contributors": [
+    "kytrinyx"
+  ],
+  "files": {
+    "solution": [
+      "lib/sum_of_multiples.dart"
+    ],
+    "test": [
+      "test/sum_of_multiples_test.dart"
+    ],
+    "example": [
+      ".meta/lib/example.dart"
+    ]
+  },
+  "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
+  "source": "A variation on Problem 1 at Project Euler",
+  "source_url": "https://projecteuler.net/problem=1"
+}

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -1,5 +1,7 @@
 {
-  "authors": [],
+  "authors": [
+    "Stargator"
+  ],
   "contributors": [
     "kytrinyx"
   ],

--- a/exercises/practice/sum-of-multiples/.meta/lib/example.dart
+++ b/exercises/practice/sum-of-multiples/.meta/lib/example.dart
@@ -1,3 +1,16 @@
 class SumOfMultiples {
-  // Write sample solution here.
+
+  int sum(List<int> rootArray, int limit) {
+    final multiplesTracked = <int>{};
+
+    for (final num in rootArray) {
+      for (int count = 1; num != 0 && (num * count) < limit; count++) {
+        multiplesTracked.add(num * count);
+      }
+    }
+
+    return multiplesTracked.fold<int>(0, _addUpMultiples);
+  }
+
+  int _addUpMultiples(int currentSum, int arrayValue) => currentSum + arrayValue;
 }

--- a/exercises/practice/sum-of-multiples/.meta/lib/example.dart
+++ b/exercises/practice/sum-of-multiples/.meta/lib/example.dart
@@ -1,0 +1,3 @@
+class SumOfMultiples {
+  // Write sample solution here.
+}

--- a/exercises/practice/sum-of-multiples/.meta/tests.toml
+++ b/exercises/practice/sum-of-multiples/.meta/tests.toml
@@ -1,0 +1,58 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[54aaab5a-ce86-4edc-8b40-d3ab2400a279]
+description = "no multiples within limit"
+
+[361e4e50-c89b-4f60-95ef-5bc5c595490a]
+description = "one factor has multiples within limit"
+
+[e644e070-040e-4ae0-9910-93c69fc3f7ce]
+description = "more than one multiple within limit"
+
+[607d6eb9-535c-41ce-91b5-3a61da3fa57f]
+description = "more than one factor with multiples within limit"
+
+[f47e8209-c0c5-4786-b07b-dc273bf86b9b]
+description = "each multiple is only counted once"
+
+[28c4b267-c980-4054-93e9-07723db615ac]
+description = "a much larger limit"
+
+[09c4494d-ff2d-4e0f-8421-f5532821ee12]
+description = "three factors"
+
+[2d0d5faa-f177-4ad6-bde9-ebb865083751]
+description = "factors not relatively prime"
+
+[ece8f2e8-96aa-4166-bbb7-6ce71261e354]
+description = "some pairs of factors relatively prime and some not"
+
+[624fdade-6ffb-400e-8472-456a38c171c0]
+description = "one factor is a multiple of another"
+
+[949ee7eb-db51-479c-b5cb-4a22b40ac057]
+description = "much larger factors"
+
+[41093673-acbd-482c-ab80-d00a0cbedecd]
+description = "all numbers are multiples of 1"
+
+[1730453b-baaa-438e-a9c2-d754497b2a76]
+description = "no factors means an empty sum"
+
+[214a01e9-f4bf-45bb-80f1-1dce9fbb0310]
+description = "the only multiple of 0 is 0"
+
+[c423ae21-a0cb-4ec7-aeb1-32971af5b510]
+description = "the factor 0 does not affect the sum of multiples of other factors"
+
+[17053ba9-112f-4ac0-aadb-0519dd836342]
+description = "solutions using include-exclude must extend to cardinality greater than 3"

--- a/exercises/practice/sum-of-multiples/analysis_options.yaml
+++ b/exercises/practice/sum-of-multiples/analysis_options.yaml
@@ -1,0 +1,18 @@
+analyzer:
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false
+  errors:
+    unused_element:        error
+    unused_import:         error
+    unused_local_variable: error
+    dead_code:             error
+
+linter:
+  rules:
+    # Error Rules
+    - avoid_relative_lib_imports
+    - avoid_types_as_parameter_names
+    - literal_only_boolean_expressions
+    - no_adjacent_strings_in_list
+    - valid_regexps

--- a/exercises/practice/sum-of-multiples/lib/sum_of_multiples.dart
+++ b/exercises/practice/sum-of-multiples/lib/sum_of_multiples.dart
@@ -1,0 +1,3 @@
+class SumOfMultiples {
+  // Put your code here
+}

--- a/exercises/practice/sum-of-multiples/pubspec.yaml
+++ b/exercises/practice/sum-of-multiples/pubspec.yaml
@@ -1,0 +1,5 @@
+name: 'sum_of_multiples'
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+dev_dependencies:
+  test: '<2.0.0'

--- a/exercises/practice/sum-of-multiples/test/sum_of_multiples_test.dart
+++ b/exercises/practice/sum-of-multiples/test/sum_of_multiples_test.dart
@@ -1,0 +1,87 @@
+import 'package:test/test.dart';
+
+void main() {
+  final sumOfMultiples = SumOfMultiples();
+
+  group('SumOfMultiples', () {
+    test('no multiples within limit', () {
+      final result = sumOfMultiples.sum(<int>[3, 5], 1);
+      expect(result, equals(0));
+    }, skip: false);
+
+    test('one factor has multiples within limit', () {
+      final result = sumOfMultiples.sum(<int>[3, 5], 4);
+      expect(result, equals(3));
+    }, skip: true);
+
+    test('more than one multiple within limit', () {
+      final result = sumOfMultiples.sum(<int>[3], 7);
+      expect(result, equals(9));
+    }, skip: true);
+
+    test('more than one factor with multiples within limit', () {
+      final result = sumOfMultiples.sum(<int>[3, 5], 10);
+      expect(result, equals(23));
+    }, skip: true);
+
+    test('each multiple is only counted once', () {
+      final result = sumOfMultiples.sum(<int>[3, 5], 100);
+      expect(result, equals(2318));
+    }, skip: true);
+
+    test('a much larger limit', () {
+      final result = sumOfMultiples.sum(<int>[3, 5], 1000);
+      expect(result, equals(233168));
+    }, skip: true);
+
+    test('three factors', () {
+      final result = sumOfMultiples.sum(<int>[7, 13, 17], 20);
+      expect(result, equals(51));
+    }, skip: true);
+
+    test('factors not relatively prime', () {
+      final result = sumOfMultiples.sum(<int>[4, 6], 15);
+      expect(result, equals(30));
+    }, skip: true);
+
+    test('some pairs of factors relatively prime and some not', () {
+      final result = sumOfMultiples.sum(<int>[5, 6, 8], 150);
+      expect(result, equals(4419));
+    }, skip: true);
+
+    test('one factor is a multiple of another', () {
+      final result = sumOfMultiples.sum(<int>[5, 25], 51);
+      expect(result, equals(275));
+    }, skip: true);
+
+    test('much larger factors', () {
+      final result = sumOfMultiples.sum(<int>[43, 47], 10000);
+      expect(result, equals(2203160));
+    }, skip: true);
+
+    test('all numbers are multiples of 1', () {
+      final result = sumOfMultiples.sum(<int>[1], 100);
+      expect(result, equals(4950));
+    }, skip: true);
+
+    test('no factors means an empty sum', () {
+      final result = sumOfMultiples.sum(<int>[], 10000);
+      expect(result, equals(0));
+    }, skip: true);
+
+    test('the only multiple of 0 is 0', () {
+      final result = sumOfMultiples.sum(<int>[0], 1);
+      expect(result, equals(0));
+    }, skip: true);
+
+    test('the factor 0 does not affect the sum of multiples of other factors', () {
+      final result = sumOfMultiples.sum(<int>[3, 0], 4);
+      expect(result, equals(3));
+    }, skip: true);
+
+    test('solutions using include-exclude must extend to cardinality greater than 3', () {
+      final result = sumOfMultiples.sum(<int>[2, 3, 5, 7, 11], 10000);
+      expect(result, equals(39614537));
+    }, skip: true);
+  });
+}

--- a/exercises/practice/sum-of-multiples/test/sum_of_multiples_test.dart
+++ b/exercises/practice/sum-of-multiples/test/sum_of_multiples_test.dart
@@ -1,3 +1,4 @@
+import 'package:sum_of_multiples/sum_of_multiples.dart';
 import 'package:test/test.dart';
 
 void main() {


### PR DESCRIPTION
This is a proposal for a new exercise based on the canonical data in the problem-specifications repository.

I didn't make any design choices whatsoever—if you think a different API would be better suited to this exercise, please suggest some changes, and I will regenerate the test suite.

I put myself as contributor rather than author, since I don't intend to write the example solution.
As such, the authorship of this exercise is up for grabs to anyone who wants to spend a few minutes writing some code that will pass the tests.
