### PR TITLE
Revert configlet fmt for pig-latin

### DIFF
--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -13,6 +13,9 @@
       ".meta/lib/example.dart"
     ]
   },
+  "forked_from": [
+    "csharp/pig-latin"
+  ],
   "blurb": "Implement a program that translates from English to Pig Latin.",
   "source": "The Pig Latin exercise at Test First Teaching by Ultrasaurus",
   "source_url": "https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/"


### PR DESCRIPTION
The fmt command removed a custom key.

This is a bug in configlet, and I'll be opening an issue
in the configlet repo to ensure that it doesn't happen in the future.
