### PR TITLE
CI: pin GitHub Actions runners

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   linkChecker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR updates GitHub Actions runners to a specific version.
This ensures that the workflow will always run on the same runner, which makes your build _stable_.

The PR updates the *-latest version with the current version, as specified in https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-test-runners-to-version for more information.