### PR TITLE
pubspec: Upgrade sdk constraints to Dart 3.2 as minimum

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: ['2.18']
+        tag: ['3.2']
 
     container:
       image:  dart:${{ matrix.tag }}

--- a/bin/create_exercise.dart
+++ b/bin/create_exercise.dart
@@ -292,7 +292,7 @@ bool _containsWhitespaceCodes(String input) {
 String _determineBestReturnType(List<dynamic> specCases) {
   final expectedList = retrieveListOfExpected(specCases);
 
-  final dynamic first = expectedList != null && expectedList.isNotEmpty ? expectedList.first : null;
+  final dynamic first = expectedList.isNotEmpty ? expectedList.first : null;
 
   if (first is Iterable) {
     final iterableType = '${_getIterableType(first)}';

--- a/exercises/concept/futures/pubspec.yaml
+++ b/exercises/concept/futures/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'futures'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/concept/numbers/pubspec.yaml
+++ b/exercises/concept/numbers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'numbers'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/concept/strings/pubspec.yaml
+++ b/exercises/concept/strings/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'strings'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/acronym/pubspec.yaml
+++ b/exercises/practice/acronym/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'acronym'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/allergies/pubspec.yaml
+++ b/exercises/practice/allergies/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'allergies'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/anagram/pubspec.yaml
+++ b/exercises/practice/anagram/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'anagram'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/armstrong-numbers/pubspec.yaml
+++ b/exercises/practice/armstrong-numbers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'armstrong_numbers'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/beer-song/pubspec.yaml
+++ b/exercises/practice/beer-song/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'beer_song'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/binary-search-tree/pubspec.yaml
+++ b/exercises/practice/binary-search-tree/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'binary_search_tree'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/bob/pubspec.yaml
+++ b/exercises/practice/bob/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'bob'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/collatz-conjecture/pubspec.yaml
+++ b/exercises/practice/collatz-conjecture/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'collatz_conjecture'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/darts/pubspec.yaml
+++ b/exercises/practice/darts/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'darts'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/diamond/pubspec.yaml
+++ b/exercises/practice/diamond/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'diamond'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/difference-of-squares/pubspec.yaml
+++ b/exercises/practice/difference-of-squares/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'difference_of_squares'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/forth/pubspec.yaml
+++ b/exercises/practice/forth/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'forth'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/gigasecond/pubspec.yaml
+++ b/exercises/practice/gigasecond/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'gigasecond'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/grains/pubspec.yaml
+++ b/exercises/practice/grains/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'grains'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/hamming/pubspec.yaml
+++ b/exercises/practice/hamming/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'hamming'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/hello-world/pubspec.yaml
+++ b/exercises/practice/hello-world/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'hello_world'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/high-scores/pubspec.yaml
+++ b/exercises/practice/high-scores/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'high_scores'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/isbn-verifier/pubspec.yaml
+++ b/exercises/practice/isbn-verifier/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'isbn_verifier'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/isogram/pubspec.yaml
+++ b/exercises/practice/isogram/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'isogram'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/leap/pubspec.yaml
+++ b/exercises/practice/leap/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'leap'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/luhn/pubspec.yaml
+++ b/exercises/practice/luhn/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'luhn'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/matching-brackets/pubspec.yaml
+++ b/exercises/practice/matching-brackets/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'matching_brackets'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/minesweeper/pubspec.yaml
+++ b/exercises/practice/minesweeper/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'minesweeper'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/nth-prime/pubspec.yaml
+++ b/exercises/practice/nth-prime/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'nth_prime'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/pangram/pubspec.yaml
+++ b/exercises/practice/pangram/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'pangram'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/pascals-triangle/pubspec.yaml
+++ b/exercises/practice/pascals-triangle/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'pascals_triangle'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/phone-number/pubspec.yaml
+++ b/exercises/practice/phone-number/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'phone_number'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/pig-latin/pubspec.yaml
+++ b/exercises/practice/pig-latin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'pig_latin'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/prime-factors/pubspec.yaml
+++ b/exercises/practice/prime-factors/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'prime_factors'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/raindrops/pubspec.yaml
+++ b/exercises/practice/raindrops/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'raindrops'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/resistor-color-duo/pubspec.yaml
+++ b/exercises/practice/resistor-color-duo/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'resistor_color_duo'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/resistor-color/pubspec.yaml
+++ b/exercises/practice/resistor-color/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'resistor_color'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/reverse-string/pubspec.yaml
+++ b/exercises/practice/reverse-string/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'reverse_string'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/rna-transcription/pubspec.yaml
+++ b/exercises/practice/rna-transcription/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'rna_transcription'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/robot-simulator/pubspec.yaml
+++ b/exercises/practice/robot-simulator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'robot_simulator'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/roman-numerals/pubspec.yaml
+++ b/exercises/practice/roman-numerals/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'roman_numerals'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/scrabble-score/pubspec.yaml
+++ b/exercises/practice/scrabble-score/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'scrabble_score'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/secret-handshake/pubspec.yaml
+++ b/exercises/practice/secret-handshake/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'secret_handshake'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/space-age/pubspec.yaml
+++ b/exercises/practice/space-age/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'space_age'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/sum-of-multiples/pubspec.yaml
+++ b/exercises/practice/sum-of-multiples/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'sum_of_multiples'
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/triangle/pubspec.yaml
+++ b/exercises/practice/triangle/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'triangle'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/two-fer/pubspec.yaml
+++ b/exercises/practice/two-fer/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'two_fer'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/exercises/practice/word-count/pubspec.yaml
+++ b/exercises/practice/word-count/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'word_count'
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 dev_dependencies:
   test: '<2.0.0'

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,50 +5,50 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: d976d24314f193899a3079b14fe336215a63a3b1e1c3743eabba8f83e049e9a9
+      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
       url: "https://pub.dev"
     source: hosted
-    version: "49.0.0"
+    version: "67.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "40ba2c6d2ab41a66476f8f1f099da6be0795c1b47221f5e2c5f8ad6048cdffae"
+      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.0"
+    version: "6.4.1"
   args:
     dependency: "direct dev"
     description:
       name: args
-      sha256: b003c3098049a51720352d219b0bb5f219b60fbfb68e7a4748139a06a5676515
+      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.2"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: "271b8899fc99f9df4f4ed419fa14e2fff392c7b2c162fbb87b222e2e963ddc73"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "5bbf32bc9e518d41ec49718e2931cd4527292c9b0c6d2dffcf7fe6b9a8a8cf72"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ef7e3a5529178ce8f37a9d0b11cbbc8b1e025940f9cf9f76c42da6796301219d
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -61,50 +61,50 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: d2494157c32b303f47dedee955b1479f2979c4ff66934eb7c0def44fd9e0267a
+      sha256: "8acabb8306b57a409bf4c83522065672ee13179297a6bb0cb9ead73948df7c76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.1"
+    version: "1.7.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   dart_style:
     dependency: "direct dev"
     description:
       name: dart_style
-      sha256: "7a03456c3490394c8e7665890333e91ae8a49be43542b616e414449ac358acd4"
+      sha256: "40ae61a5d43feea6d24bd22c0537a6629db858963b99b4bc1c3db80676f32368"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.4"
+    version: "2.3.4"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.0"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      sha256: "01fb90a581ee2bbca0a1c72b04f73b5e9e89b89bf608c9dfa815ea9cec00f11c"
+      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.2.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      sha256: c51b4fdfee4d281f49b8c957f1add91b815473597f76bcf07377987f66a55729
+      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   http_multi_server:
     dependency: transitive
     description:
@@ -117,66 +117,66 @@ packages:
     dependency: transitive
     description:
       name: http_parser
-      sha256: db3060f22889f3d9d55f6a217565486737037eec3609f7f3eca4d0c67ee0d8a0
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.2"
   io:
     dependency: "direct dev"
     description:
       name: io
-      sha256: "0d4c73c3653ab85bf696d51a9657604c900a370549196a91f33e4c39af760852"
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
-      sha256: a5e201311cb08bf3912ebbe9a2be096e182d703f881136ec1e81a2338a9e120d
+      sha256: "4186c61b32f99e60f011f7160e32c89a758ae9b1d0c6d28e2c02ef0382300e2b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.7.0"
   logging:
     dependency: transitive
     description:
       name: logging
-      sha256: c0bbfe94d46aedf9b8b3e695cf3bd48c8e14b35e3b2c639e0aa7755d589ba946
+      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "80c2989398773fa06e2457e9ff08580f24e9858b28462a722241cb53e5613478"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.16+1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      sha256: dab22e92b41aa1255ea90ddc4bc2feaf35544fd0728e209638cad041a6e3928a
+      sha256: "2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.5"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      sha256: "8ebdbaa3b96d5285d068f80772390d27c21e1fa10fb2df6627b1b9415043608d"
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   pool:
     dependency: transitive
     description:
@@ -205,90 +205,90 @@ packages:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "816c1a640e952d213ddd223b3e7aafae08cd9f8e1f6864eed304cc13b0272b07"
+      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.4"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
+      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      sha256: aef74dc9195746a384843102142ab65b6a4735bb3beea791e63527b88cc83306
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      sha256: e792b76b96a36d4a41b819da593aff4bdd413576b3ba6150df5d8d9996d2e74c
+      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "6db16374bc3497d21aa0eebe674d3db9fdf82082aac0f04dc7b44e4af5b08afc"
+      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.4"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      sha256: "8c463326277f68a628abab20580047b419c2ff66756fd0affd451f73f9508c11"
+      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      sha256: "52de2200bb098de739794c82d09c41ac27b2e42fd7e23cce7b9c74bf653c7296"
+      sha256: "708b3f6b97248e5781f493b765c3337db11c5d2c81c3094f10904bfa8004c703"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.10"
+    version: "0.10.12"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: f8d9f247e2f9f90e32d1495ff32dac7e4ae34ffa7194c5ff8fcc0fd0e52df774
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "862015c5db1f3f3c4ea3b94dc2490363a84262994b88902315ed74be1155612f"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -301,73 +301,81 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "9ffb8dbda445ba2922522423e7c7288967de89129205ce2dadf856abfd2b72ae"
+      sha256: "7ee446762c2c50b3bd4ea96fe13ffac69919352bd3b4b17bac3f3465edc58073"
       url: "https://pub.dev"
     source: hosted
-    version: "1.21.6"
+    version: "1.25.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ceeddf59d613e862e77f4b506cfc2945ac9637ce0b4c00f4f4c1ac639f3e9731
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.14"
+    version: "0.7.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "2b38b8ecfa37f8d375b4aa2a106a86ade536b577411530c2ea68c83abb1f004b"
+      sha256: "2bc4b4ecddd75309300d8096f781c0e3280ca1ef85beda558d33fcbedc2eead4"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.18"
+    version: "0.6.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: e7fb6c2282f7631712b69c19d1bff82f3767eea33a2321c14fa59ad67ea391c7
+      sha256: a2662fb1f114f4296cf3f5a50786a2d888268d7776cf681aa17d660ffa23b246
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.0"
+    version: "14.0.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: e42dfcc48f67618344da967b10f62de57e04bae01d9d3af4c2596f3712a88c99
+      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "4188706108906f002b3a293509234588823c8c979dc83304e229ff400c996b05"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.2"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "3a969ddcc204a3e34e863d204b29c0752716f78b6f9cc8235083208d268a4ccd"
+      sha256: "939ab60734a4f8fa95feacb55804fa278de28bdeef38e616dc08e44a84adea23"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.3"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   yaml:
     dependency: "direct dev"
     description:
       name: yaml
-      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
 sdks:
-  dart: ">=2.18.0 <4.0.0"
+  dart: ">=3.2.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: exercism_dart
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 authors:
   - SuperPaintman <SuperPaintmanDeveloper@gmail.com>
   - Stargator <wildbug@linuxmail.org>
@@ -8,8 +8,8 @@ authors:
   - devkabiir
   - jvarness <jake.varness@gmail.com>
 dev_dependencies:
-  args: '^2.0.0'
-  dart_style: '^2.0.0'
-  io: '^1.0.0'
-  test: '>=1.21.6 <2.0.0'
-  yaml: '^3.1.0'
+  args: ^2.4.2
+  dart_style: ^2.3.4
+  io: ^1.0.4
+  test: ^1.25.2
+  yaml: ^3.1.2


### PR DESCRIPTION
Upgrade our minimum SDK constraint to 3.2 (the latest version of Dart)