### PR TITLE
Add the invalidator to the track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -30,6 +30,9 @@
     ],
     "exemplar": [
       ".meta/exemplar.dart"
+    ],
+    "invalidator": [
+      "pubspec.yaml"
     ]
   },
   "exercises": {


### PR DESCRIPTION
I forgot to do this in #533.
Now new exercises (via `configlet create`) should get the invalidator file in the exercise config.