### PR TITLE
yacht: fix enum order

### DIFF
--- a/exercises/practice/yacht/lib/categories.dart
+++ b/exercises/practice/yacht/lib/categories.dart
@@ -1,8 +1,8 @@
 enum Category {
   ones,
   twos,
-  fours,
   threes,
+  fours,
   fives,
   sixes,
   full_house,


### PR DESCRIPTION
https://forum.exercism.org/t/yacht-the-order-of-threes-fours-in-enum-category/10931