### PR TITLE
Separate format check and analyzer code into new actions

### DIFF
--- a/.github/workflows/analyze-code.yml
+++ b/.github/workflows/analyze-code.yml
@@ -1,0 +1,36 @@
+name: Analyze Code
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/test.yml'
+      - 'bin/*.dart'
+      - 'exercises/**/*.dart'
+      - 'exercises/**/analysis_options.yaml'
+      - 'exercises/**/pubspec.yaml'
+      - 'lib/*.dart'
+      - 'lib/src/*.dart'
+      - 'test/*.dart'
+      - 'analysis_options.yaml'
+      - 'pubspec.*'
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: ['3.2']
+
+    container:
+      image:  dart:${{ matrix.tag }}
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Install dependencies
+        run: dart pub get
+
+      # We can't check the exercises because they will produce errors since the example files have the solution.
+      - name: Analyze Dart code
+        run: dart analyze bin/ lib/ test/

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: Check Formatting
 
 on:
   pull_request:
@@ -26,10 +26,11 @@ jobs:
       image:  dart:${{ matrix.tag }}
 
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-    - name: Install dependencies
-      run: dart pub get
+      - name: Install dependencies
+        run: dart pub get
 
-    - name: Run tests
-      run: dart test
+      - name: Check Stage formatting
+        run: dart run bin/check_formatting.dart
+


### PR DESCRIPTION
Addresses #591

Separating the Format Check and Code Analyzing into separate actions.

In a future PR, we can look at trying to get more details into the Format job's logs to know which files were not formatted.