### PR TITLE
Declaring collections as a direct dev dependency rather than a transitive one

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,7 +42,7 @@ packages:
     source: hosted
     version: "2.1.1"
   collection:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: collection
       sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,3 +13,4 @@ dev_dependencies:
   io: ^1.0.4
   test: ^1.25.2
   yaml: ^3.1.2
+  collection: ^1.18.0


### PR DESCRIPTION
This PR declares `collections: 1.18.0` as a direct dev dependency rather than a transitive one in order to keep Exercism solutions created with it safe for upgrade.