### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/nucleotide-count/.docs/instructions.append.md
+++ b/exercises/practice/nucleotide-count/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 There are times when you need to handle unexpected issues that arise during code execution.
 In Dart, you can use exceptions to handle these situations.
 

--- a/exercises/practice/phone-number/.docs/instructions.append.md
+++ b/exercises/practice/phone-number/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Tip
+# Instructions append
+
+## Tip
 
 A function with a *return type* can only return data of that *type* and `null`.
 However the function caller is only expecting one data type.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.